### PR TITLE
Calculate unit quaternion from Euler angles

### DIFF
--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -250,4 +250,4 @@ def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     q_y = cos_gamma2 * sin_beta2 * cos_alpha2 + sin_gamma2 * cos_beta2 * sin_alpha2
     q_z = sin_gamma2 * cos_beta2 * cos_alpha2 - cos_gamma2 * sin_beta2 * sin_alpha2
 
-    return _normalize(np.array([q_w, -q_x, -q_y, -q_z]))
+    return _normalize(np.array([q_w, -q_x, -q_y, -q_z]))  # type: ignore[no-any-return]  # see _normalize

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -230,7 +230,7 @@ def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
 
     Return
     ------
-    rot : 1D array (3,)
+    q : 1D array (3,)
         Unit quaternion.
 
     """

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -4,6 +4,8 @@ import numpy as np
 from numba import njit
 from numpy.typing import NDArray
 
+from smsfusion._vectorops import _normalize
+
 
 def _angular_matrix_from_euler(
     alpha_beta_gamma: NDArray[np.float64],
@@ -248,7 +250,4 @@ def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     q_y = cos_gamma2 * sin_beta2 * cos_alpha2 + sin_gamma2 * cos_beta2 * sin_alpha2
     q_z = sin_gamma2 * cos_beta2 * cos_alpha2 - cos_gamma2 * sin_beta2 * sin_alpha2
 
-    q = np.array([q_w, -q_x, -q_y, -q_z])
-    q /= np.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3] ** 2)  # ensure unit norm
-
-    return q
+    return _normalize(np.array([q_w, -q_x, -q_y, -q_z]))

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -217,7 +217,8 @@ def _rot_matrix_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     return rot
 
 
-def _quaternion_from_euler(euler):
+@njit  # type: ignore[misc]
+def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     alpha2, beta2, gamma2 = euler / 2  # half angles
 
     cos_alpha2 = np.cos(alpha2)

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -182,7 +182,7 @@ def _rot_matrix_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     Parameters
     ----------
     euler : 1D array (3,)
-        Euler angle in radians given as (roll, pitch, yaw) but rotaions are applied
+        Euler angle in radians given as (roll, pitch, yaw) but rotations are applied
         according to the ZYX convention. That is, **yaw -> pitch -> roll**.
 
     Return
@@ -219,8 +219,22 @@ def _rot_matrix_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
 
 @njit  # type: ignore[misc]
 def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
-    alpha2, beta2, gamma2 = euler / 2  # half angles
+    """
+    Unit quaternion defined from Euler angles (ZYX convention) (passive rotations).
 
+    Parameters
+    ----------
+    euler : 1D array (3,)
+        Euler angle in radians given as (roll, pitch, yaw) but rotations are applied
+        according to the ZYX convention. That is, **yaw -> pitch -> roll**.
+
+    Return
+    ------
+    rot : 1D array (3,)
+        Unit quaternion.
+
+    """
+    alpha2, beta2, gamma2 = euler / 2  # half angles
     cos_alpha2 = np.cos(alpha2)
     sin_alpha2 = np.sin(alpha2)
     cos_beta2 = np.cos(beta2)

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -235,6 +235,6 @@ def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
     q_z = sin_gamma2 * cos_beta2 * cos_alpha2 - cos_gamma2 * sin_beta2 * sin_alpha2
 
     q = np.array([q_w, -q_x, -q_y, -q_z])
-    q /= np.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3]**2)  # ensure unit norm
+    q /= np.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3] ** 2)  # ensure unit norm
 
     return q

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -234,7 +234,7 @@ def _quaternion_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
         Unit quaternion.
 
     """
-    alpha2, beta2, gamma2 = euler / 2  # half angles
+    alpha2, beta2, gamma2 = euler / 2.0  # half angles
     cos_alpha2 = np.cos(alpha2)
     sin_alpha2 = np.sin(alpha2)
     cos_beta2 = np.cos(beta2)

--- a/src/smsfusion/_transforms.py
+++ b/src/smsfusion/_transforms.py
@@ -215,3 +215,25 @@ def _rot_matrix_from_euler(euler: NDArray[np.float64]) -> NDArray[np.float64]:
         [[rot_00, rot_01, rot_02], [rot_10, rot_11, rot_12], [rot_20, rot_21, rot_22]]
     )
     return rot
+
+
+def _quaternion_from_euler(euler):
+    alpha2, beta2, gamma2 = euler / 2  # half angles
+
+    cos_alpha2 = np.cos(alpha2)
+    sin_alpha2 = np.sin(alpha2)
+    cos_beta2 = np.cos(beta2)
+    sin_beta2 = np.sin(beta2)
+    cos_gamma2 = np.cos(gamma2)
+    sin_gamma2 = np.sin(gamma2)
+
+    # Quaternion
+    q_w = cos_gamma2 * cos_beta2 * cos_alpha2 + sin_gamma2 * sin_beta2 * sin_alpha2
+    q_x = cos_gamma2 * cos_beta2 * sin_alpha2 - sin_gamma2 * sin_beta2 * cos_alpha2
+    q_y = cos_gamma2 * sin_beta2 * cos_alpha2 + sin_gamma2 * cos_beta2 * sin_alpha2
+    q_z = sin_gamma2 * cos_beta2 * cos_alpha2 - cos_gamma2 * sin_beta2 * sin_alpha2
+
+    q = np.array([q_w, -q_x, -q_y, -q_z])
+    q /= np.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3]**2)  # ensure unit norm
+
+    return q

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -241,12 +241,12 @@ def test__rot_matrix_from_euler(euler):
 
 
 def test__quaternion_from_euler():
-    euler = np.random.random(3)   # passive rotations
+    euler = np.random.random(3)  # passive rotations
 
     q_out = _transforms._quaternion_from_euler(euler)
 
-    q_expect = Rotation.from_euler("ZYX", euler[::-1]).as_quat()   # active rotations
+    q_expect = Rotation.from_euler("ZYX", euler[::-1]).as_quat()  # active rotations
     q_expect = np.r_[q_expect[3], q_expect[:3]]
-    q_expect[1:] *= -1
+    q_expect[1:] *= -1  # passive rotations
 
     np.testing.assert_array_almost_equal(q_out, q_expect)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -238,3 +238,15 @@ def test__rot_matrix_from_euler(euler):
     out = _transforms._rot_matrix_from_euler(euler)
     expected = Rotation.from_euler("ZYX", euler[::-1]).inv().as_matrix()
     np.testing.assert_array_almost_equal(out, expected)
+
+
+def test__quaternion_from_euler():
+    euler = np.random.random(3)   # passive rotations
+
+    q_out = _transforms._quaternion_from_euler(euler)
+
+    q_expect = Rotation.from_euler("ZYX", euler[::-1]).as_quat()   # active rotations
+    q_expect = np.r_[q_expect[3], q_expect[:3]]
+    q_expect[1:] *= -1
+
+    np.testing.assert_array_almost_equal(q_out, q_expect)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -241,7 +241,7 @@ def test__rot_matrix_from_euler(euler):
 
 
 def test__quaternion_from_euler():
-    euler = np.random.random(3)  # passive rotations
+    euler = np.random.random(3) * np.pi  # passive rotations
 
     q_out = _transforms._quaternion_from_euler(euler)
 


### PR DESCRIPTION
### This PR is related to user story DLAB-31

## Description
Functionality for calculating unit quaternion from Euler angles.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
