### PR TITLE
Fix wrong rotation in AHRS update algorithm

### DIFF
--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -169,21 +169,20 @@ class AHRS:
         if head_degrees:
             head = np.radians(head)
 
+        R_bn = _rot_matrix_from_quaternion(self._q).T
+
         # Reference vectors expressed in NED frame
-        v01 = np.array([0.0, 0.0, 1.0], dtype=np.float64)  # direction of gravity
-        v02 = np.array([1.0, 0.0, 0.0], dtype=np.float64)  # direction of north
+        v1 = np.array([0.0, 0.0, 1.0], dtype=np.float64)  # direction of gravity
+        v2 = np.array([1.0, 0.0, 0.0], dtype=np.float64)  # direction of north
+
+        v1_mes = -_normalize(f_imu)
+        v1_est = R_bn @ v1
 
         delta_head = head - _gamma_from_quaternion(self._q)
-
-        R_nb = _rot_matrix_from_quaternion(self._q)
-
-        v1_meas = -_normalize(f_imu)
-        v1_est = R_nb @ v01
+        v2_mes = np.array([np.cos(delta_head), -np.sin(delta_head), 0.0])
 
         # postpone rotation to after cross product
-        v2_meas = np.array([np.cos(delta_head), -np.sin(delta_head), 0.0])
-
-        w_mes = _cross(v1_meas, v1_est) + R_nb @ _cross(v2_meas, v02)
+        w_mes = _cross(v1_mes, v1_est) + R_bn @ _cross(v2_mes, v2)
 
         self._q, self._bias, self._error = self._update(
             self._dt, self._q, self._bias, w_imu, w_mes, self._Kp, self._Ki


### PR DESCRIPTION
### This PR is related to user story DLAB-38

## Description
After updating all internal rotation related functions to "body-to-origin", the rotation applied inside the AHRS update algorithm  unintentionally changed to "body-to-origin", but should be "origin-to-body".

In addition, some code refactoring for better readability is applied.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
