### PR TITLE
Allow irregular position aiding in `AidedINS`

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -548,7 +548,7 @@ class AidedINS:
         f_imu: ArrayLike,
         w_imu: ArrayLike,
         head: float,
-        pos: ArrayLike | None,
+        pos: ArrayLike | None = None,
         degrees: bool = False,
         head_degrees: bool = True,
     ) -> None:
@@ -568,7 +568,7 @@ class AidedINS:
         head : float
             Heading measurement, i.e., yaw angle. If `head_degrees` is `True`, the
             heading is assumed to be in degrees; otherwise, in radians.
-        pos : array-like (3,), optional
+        pos : array-like (3,), default=None
             Position aiding measurement. If `None`, no position aiding is used.
         degrees : bool, default=False
             Specifies the units of the `w_imu` parameter. If `True`, the rotation

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -584,7 +584,6 @@ class AidedINS:
 
         if pos is not None:
             pos = np.asarray_chkfinite(pos, dtype=float).reshape(3, 1).copy()
-            # z = np.r_[pos, theta_ext.reshape(3, 1)]  # measurement vector
             z = np.vstack([pos, theta_ext.reshape(3, 1)])  # measurement vector
             H = self._H  # measurement matrix
             R = self._R  # measurement noise covariance matrix
@@ -610,9 +609,7 @@ class AidedINS:
 
         F = self._F  # state matrix
         G = self._G  # (white noise) input matrix
-        # H = self._H  # measurement matrix
         W = self._W  # white noise power spectral density matrix
-        # R = self._R  # measurement noise covariance matrix
         P_prior = self._P_prior  # error covariance matrix
         I15 = self._I15  # 15x15 identity matrix
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -326,7 +326,6 @@ class AidedINS:
         - Assumes aiding measurements are available at every time step.
         - Supports only position and AHRS aiding.
         - Operates at a constant sampling rate.
-        - AHRS gain factor parameters are not configurable.
         - Initial error covariance matrix, P, is fixed to the identity matrix, and
           cannot be set during initialization.
         - Update method is not properly tested.

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -323,7 +323,6 @@ class AidedINS:
     Notes
     -----
     This AINS model has the following limitations:
-        - Assumes aiding measurements are available at every time step.
         - Supports only position and AHRS aiding.
         - Operates at a constant sampling rate.
         - Initial error covariance matrix, P, is fixed to the identity matrix, and

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -569,8 +569,8 @@ class AidedINS:
         head : float
             Heading measurement, i.e., yaw angle. If `head_degrees` is `True`, the
             heading is assumed to be in degrees; otherwise, in radians.
-        pos : array-like (3,)
-            Position measurement.
+        pos : array-like (3,), optional
+            Position aiding measurement. If `None`, no position aiding is used.
         degrees : bool, default=False
             Specifies the units of the `w_imu` parameter. If `True`, the rotation
             rates are assumed to be in degrees; otherwise, in radians.

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -455,7 +455,9 @@ class Test_AidedINS:
         head = 0.0
         pos = np.zeros(3)
 
+        ains.update(f_imu, w_imu, head, None, degrees=True, head_degrees=True)  # no pos
+        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
         ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)  # pos
         np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
-        ains.update(f_imu, w_imu, head, None, degrees=True, head_degrees=True)  # no pos
+        ains.update(f_imu, w_imu, head, degrees=True, head_degrees=True)  # no pos
         np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -436,3 +436,26 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
         ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)
         np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+
+    def test_update_irregular_position_aiding(self):
+        fs = 10.24
+
+        x0 = np.zeros(15)
+        err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
+        err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
+        var_pos = np.ones(3)
+        var_ahrs = np.ones(3)
+
+        ahrs = AHRS(fs, 0.050, 0.035)
+        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_ahrs, ahrs)
+
+        g = gravity()
+        f_imu = np.array([0.0, 0.0, -g])
+        w_imu = np.zeros(3)
+        head = 0.0
+        pos = np.zeros(3)
+
+        ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)  # pos
+        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        ains.update(f_imu, w_imu, head, None, degrees=True, head_degrees=True)  # no pos
+        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))


### PR DESCRIPTION
### This PR is related to user story DLAB-33

## Description
Allow for irregular position aiding in the `AidedINS` class.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
