### PR TITLE
Make .update methods return self for easier daisy-chaining

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -551,7 +551,7 @@ class AidedINS:
         pos: ArrayLike | None = None,
         degrees: bool = False,
         head_degrees: bool = True,
-    ) -> None:
+    ) -> "AidedINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11
         """
         Update the AINS state estimates based on measurements, and project ahead.
 
@@ -636,3 +636,5 @@ class AidedINS:
         self._ins.update(self._dt, f_ins, w_ins, theta_ext=theta_ext, degrees=False)
         self.ahrs.update(f_imu, w_imu, head, degrees=False, head_degrees=False)
         self._P_prior = phi @ P @ phi.T + Q
+
+        return self

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -223,7 +223,7 @@ class StrapdownINS:
         w_imu: ArrayLike,
         degrees: bool = False,
         theta_ext: ArrayLike | None = None,
-    ) -> None:
+    ) -> "StrapdownINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11:
         """
         Update the INS states by integrating the 'strapdown navigation equations'.
 
@@ -285,6 +285,8 @@ class StrapdownINS:
         self._p = self._p + dt * self._v + 0.5 * dt**2 * a
         self._v = self._v + dt * a
         self._theta = self._theta + dt * T @ w_imu
+
+        return self
 
 
 class AidedINS:

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -193,6 +193,22 @@ class Test_AHRS:
         np.testing.assert_array_almost_equal(alg.error, error_expect)
         np.testing.assert_array_almost_equal(alg.bias, bias_expect)
 
+    def test_update_return_self(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+        q_init = np.array([1.0, 0.0, 0.0, 0.0])
+        bias_init = np.array([0.0, 0.0, 0.0])
+
+        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+
+        f_imu = np.array([0.0, 0.0, -9.80665])
+        w_imu = np.array([0.0, 0.0, 0.0])
+        head = 0.
+
+        update_return = alg.update(f_imu, w_imu, head)
+        assert update_return is alg
+
     @pytest.mark.parametrize(
         "f_imu, w_imu, head",
         [

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pandas import read_parquet
 
-from smsfusion import _ahrs
+from smsfusion._ahrs import AHRS
 from smsfusion._transforms import _quaternion_from_euler
 
 
@@ -24,9 +24,9 @@ class Test_AHRS:
         q_init = np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0)
         bias_init = np.array([0.1, 0.2, 0.3])
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
 
-        assert isinstance(alg, _ahrs.AHRS)
+        assert isinstance(alg, AHRS)
         assert alg._fs == fs
         assert alg._dt == 1.0 / fs
         assert alg._Kp == Kp
@@ -41,7 +41,7 @@ class Test_AHRS:
         Ki = 0.1
         q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
 
         q_expect = q_init
         np.testing.assert_array_almost_equal(alg.q, q_expect)
@@ -53,7 +53,7 @@ class Test_AHRS:
         q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0, 0.0], dtype=float)
 
         with pytest.raises(ValueError):
-            _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+            AHRS(fs, Kp, Ki, q_init=q_init)
 
     def test_q_init_notunity(self):
         fs = 10.24
@@ -62,7 +62,7 @@ class Test_AHRS:
         q_init = np.array([2, -1, 0.0, 0.0], dtype=float)
 
         with pytest.warns():
-            _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+            AHRS(fs, Kp, Ki, q_init=q_init)
 
     def test_q_init_none(self):
         fs = 10.24
@@ -70,7 +70,7 @@ class Test_AHRS:
         Ki = 0.1
         q_init = None
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
 
         q_expect = np.array([1.0, 0.0, 0.0, 0.0])
         np.testing.assert_array_almost_equal(alg.q, q_expect)
@@ -81,7 +81,7 @@ class Test_AHRS:
         Ki = 0.1
         bias_init = np.array([0.96591925, -0.25882081, 0.0], dtype=float)
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, bias_init=bias_init)
 
         bias_expect = bias_init
         np.testing.assert_array_almost_equal(alg.bias, bias_expect)
@@ -92,7 +92,7 @@ class Test_AHRS:
         Ki = 0.1
         bias_init = None
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, bias_init=bias_init)
 
         bias_expect = np.array([0.0, 0.0, 0.0])
         np.testing.assert_array_almost_equal(alg.bias, bias_expect)
@@ -104,14 +104,14 @@ class Test_AHRS:
         bias_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
 
         with pytest.raises(ValueError):
-            _ahrs.AHRS(fs, Kp, Ki, bias_init=bias_init)
+            AHRS(fs, Kp, Ki, bias_init=bias_init)
 
     def test_attitude(self):
         fs = 10.24
         Kp = 0.5
         Ki = 0.1
         q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
 
         alpha_beta_gamma = np.array([-30.0, 0.0, 0.0], dtype=float)
         np.testing.assert_array_almost_equal(
@@ -133,7 +133,7 @@ class Test_AHRS:
         Ki = 0.5
         Kp = 0.0
 
-        q, bias, error = _ahrs.AHRS._update(dt, q, bias, omega_gyro, omega_corr, Kp, Ki)
+        q, bias, error = AHRS._update(dt, q, bias, omega_gyro, omega_corr, Kp, Ki)
 
         q_expect = np.array([0.979986, 0.0246221, 0.0982436, 0.171375])
         error_expect = omega_corr
@@ -152,7 +152,7 @@ class Test_AHRS:
         Ki = 0.0
         Kp = 0.5
 
-        q, bias, error = _ahrs.AHRS._update(dt, q, bias, omega_gyro, omega_corr, Kp, Ki)
+        q, bias, error = AHRS._update(dt, q, bias, omega_gyro, omega_corr, Kp, Ki)
 
         q_expect = np.array([0.9843562, 0.0762876, 0.1033574, 0.1205836])
         error_expect = omega_corr
@@ -172,7 +172,7 @@ class Test_AHRS:
         q_init = np.array([1.0, 0.0, 0.0, 0.0])
         bias_init = np.array([0.0, 0.0, 0.0])
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
 
         f_imu = np.array([0.3422471493375811, -0.0, -9.800676053786814])
         w_imu = np.array([1.0, 0.0, 0.0])
@@ -197,14 +197,12 @@ class Test_AHRS:
         fs = 10.24
         Kp = 0.5
         Ki = 0.1
-        q_init = np.array([1.0, 0.0, 0.0, 0.0])
-        bias_init = np.array([0.0, 0.0, 0.0])
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki)
 
         f_imu = np.array([0.0, 0.0, -9.80665])
         w_imu = np.array([0.0, 0.0, 0.0])
-        head = 0.
+        head = 0.0
 
         update_return = alg.update(f_imu, w_imu, head)
         assert update_return is alg
@@ -229,7 +227,7 @@ class Test_AHRS:
         q_init = np.array([1.0, 0.0, 0.0, 0.0])
         bias_init = np.array([0.0, 0.0, 0.0])
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
         alg.update(f_imu, w_imu, head)
 
         q_expect = np.array([1.0, 0.0, 0.0, 0.0])
@@ -259,7 +257,7 @@ class Test_AHRS:
         q_init = np.array([1.0, 0.0, 0.0, 0.0])
         bias_init = np.array([0.0, 0.0, 0.0])
 
-        alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init, bias_init=bias_init)
         with pytest.raises((TypeError, ValueError)):
             alg.update(f_imu, w_imu, head)
 
@@ -273,7 +271,7 @@ class Test_AHRS:
         w_imu = np.random.random((100, 3))
         head = np.random.random(100)
 
-        alg = _ahrs.AHRS(fs, Kp, Ki)
+        alg = AHRS(fs, Kp, Ki)
         _ = [
             alg.update(f_imu_i, w_imu_i, head_i).q
             for f_imu_i, w_imu_i, head_i in zip(f_imu, w_imu, head)
@@ -293,7 +291,7 @@ class Test_AHRS:
         q_init = _quaternion_from_euler(
             np.radians(ahrs_ref_data[["Alpha", "Beta", "Gamma"]].values[0])
         )
-        ahrs = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
+        ahrs = AHRS(fs, Kp, Ki, q_init=q_init)
         euler_out = np.array(
             [
                 ahrs.update(f_imu_i, w_imu_i, head_i).attitude(degrees=True)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -429,6 +429,31 @@ class Test_AidedINS:
 
         np.testing.assert_array_almost_equal(H_out, H_expect)
 
+    def test_update_return_self(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+
+        x0 = np.zeros(15)
+        err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
+        err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
+        var_pos = np.ones(3)
+        var_ahrs = np.ones(3)
+
+        ahrs = AHRS(fs, Kp, Ki)
+        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_ahrs, ahrs)
+
+        g = gravity()
+        f_imu = np.array([0.0, 0.0, -g])
+        w_imu = np.zeros(3)
+        head = 0.0
+        pos = np.zeros(3)
+
+        update_return = ains.update(
+            f_imu, w_imu, head, pos, degrees=True, head_degrees=True
+        )
+        assert update_return is ains
+
     def test_update_standstill(self):
         fs = 10.24
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -110,6 +110,18 @@ class Test_StrapdownINS:
 
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
+    def test_update_return_self(self):
+        x0 = np.zeros((9, 1))
+        strapdownins = StrapdownINS(x0)
+
+        dt = 0.1
+        g = 9.80665
+        f = np.array([0.0, 0.0, -g]).reshape(-1, 1)
+        w = np.array([0.0, 0.0, 0.0]).reshape(-1, 1)
+
+        update_return = strapdownins.update(dt, f, w)
+        assert update_return is strapdownins
+
     def test_update(self):
         x0 = np.zeros((9, 1))
         ins = StrapdownINS(x0)


### PR DESCRIPTION
### This PR is related to user story DLAB-46

## Description
Make .update method return self for easiser daisy-chaining for AIdedINS, AHRS, and StrapdownINS.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
