### PR TITLE
Change definiton of Ki in AHRS

### DIFF
--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -120,7 +120,7 @@ class AHRS:
             sensors (accelerometer, magnetometer, compass) as 1D array.
 
         """
-        bias = bias - 0.5 * Ki * w_mes * dt
+        bias = bias - Ki * w_mes * dt
 
         w = w_imu - bias + Kp * w_mes
 

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -130,7 +130,7 @@ class Test_AHRS:
         bias = np.array([0.5, 0.0, -0.5])
         omega_gyro = np.array([1.0, 2.0, 3.0])
         omega_corr = np.array([0.1, 0.2, -0.1])
-        Ki = 0.5
+        Ki = 0.25
         Kp = 0.0
 
         q, bias, error = _ahrs.AHRS._update(dt, q, bias, omega_gyro, omega_corr, Kp, Ki)
@@ -168,7 +168,7 @@ class Test_AHRS:
     def test_update(self, degrees, head_degrees):
         fs = 10.24
         Kp = 0.5
-        Ki = 0.1
+        Ki = 0.05
         q_init = np.array([1.0, 0.0, 0.0, 0.0])
         bias_init = np.array([0.0, 0.0, 0.0])
 
@@ -272,7 +272,7 @@ class Test_AHRS:
 
         fs = 10.24
         Kp = 0.27
-        Ki = 0.05
+        Ki = 0.025
 
         q_init = _quaternion_from_euler(
             np.radians(ahrs_ref_data[["Alpha", "Beta", "Gamma"]].values[0])

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -494,7 +494,7 @@ class Test_AidedINS:
 
         # AHRS
         Kp = 0.27
-        Ki = 0.05
+        Ki = 0.025
 
         q_init = _quaternion_from_euler(
             np.radians(ains_ref_data[["Alpha", "Beta", "Gamma"]].values[0])


### PR DESCRIPTION
### This PR is related to user story DLAB-48

## Description
Change definition of Ki in AHRS to align with documentation and original work.

Ki/2 -> Ki, which means that Ki inputs needs to be divided by 2.
E.g.

Old:
```
Kp = 0.27
Ki = 0.05
```
New:
```
Kp = 0.27
Ki = 0.025
```


## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
