### PR TITLE
Consistent naming across all state estimators

### DIFF
--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -196,13 +196,19 @@ class AHRS:
         Parameters
         ----------
         degrees : bool
-            Whether to return the attitude in degrees (default) or radians.
+            Whether to return the Euler angles in degrees (`True`) or radians (`False`).
 
         Returns
         -------
-        attitude : ndarray
-            Euler angles, i.e., roll, pitch and yaw (in that order). However, the angles
-            are according to the ZYX convention.
+        euler : numpy.ndarray
+            Euler angles, i.e., roll, pitch and yaw (in that order).
+
+        Notes
+        -----
+        The Euler angles describe how to transition from the 'NED' frame to the 'body'
+        frame through three consecutive (passive, intrinsic) rotations in the ZYX order.
+        That is, first rotate about the z-axis (gamma), then about the y-axis
+        (pitch), and lastly about the x-axis (roll).
         """
         euler = _euler_from_quaternion(self._q)
         if degrees:

--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -189,9 +189,9 @@ class AHRS:
         )
         return self
 
-    def attitude(self, degrees: bool = True) -> NDArray[np.float64]:
+    def euler(self, degrees: bool = True) -> NDArray[np.float64]:
         """
-        Current attitude estimate as Euler angles in ZYX convention.
+        Current attitude estimate as Euler angles in ZYX convention, see Notes.
 
         Parameters
         ----------
@@ -204,28 +204,28 @@ class AHRS:
             Euler angles, i.e., roll, pitch and yaw (in that order). However, the angles
             are according to the ZYX convention.
         """
-        attitude = _euler_from_quaternion(self._q)
+        euler = _euler_from_quaternion(self._q)
         if degrees:
-            attitude = np.degrees(attitude)
-        return attitude  # type: ignore[no-any-return]  # numpy funcs declare Any as return when given scalar-like
+            euler = np.degrees(euler)
+        return euler  # type: ignore[no-any-return]  # numpy funcs declare Any as return when given scalar-like
 
     @property
-    def q(self) -> NDArray[np.float64]:
+    def quaternion(self) -> NDArray[np.float64]:
         """
-        Get current attitude (quaternion) estimate.
+        Current attitude estimate as unit quaternion (from-body-to-NED).
         """
         return self._q.copy()
 
     @property
     def error(self) -> NDArray[np.float64]:
         """
-        Get current error estimate.
+        Current error estimate.
         """
         return self._error.copy()
 
     @property
     def bias(self) -> NDArray[np.float64]:
         """
-        Get current bias estimate.
+        Current bias estimate.
         """
         return self._bias.copy()

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -5,7 +5,7 @@ from numpy.linalg import inv
 from numpy.typing import ArrayLike, NDArray
 
 from ._ahrs import AHRS
-from ._transforms import _angular_matrix_from_euler, _rot_matrix_from_euler
+from ._transforms import _angular_matrix_from_euler, _rot_matrix_from_euler, _quaternion_from_euler
 
 
 def gravity(lat: float | None = None, degrees: bool = True) -> float:
@@ -443,7 +443,7 @@ class AidedINS:
 
     def euler(self, degrees: bool = False) -> NDArray[np.float64]:
         """
-        Current AINS attitude estimate as Euler angles (i.e., roll, pitch, yaw).
+        Current attitude estimate as Euler angles in ZYX convention, see Notes.
 
         Parameters
         ----------
@@ -465,6 +465,12 @@ class AidedINS:
             theta = (180.0 / np.pi) * theta
 
         return theta
+
+    def quaternion(self) -> NDArray[np.float64]:
+        """
+        Current attitude estimate as unit quaternion (from-body-to-NED).
+        """
+        return _quaternion_from_euler(self._theta.flatten())
 
     @staticmethod
     def _prep_F_matrix(

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -173,7 +173,7 @@ class StrapdownINS:
         Parameters
         ----------
         degrees : bool
-            Whether to return the attitude in degrees (default) or radians.
+            Whether to return the Euler angles in degrees (`True`) or radians (`False`).
 
         Returns
         -------
@@ -447,9 +447,8 @@ class AidedINS:
 
         Parameters
         ----------
-        degrees : bool, default=False
-            If `True`, the Euler angles are returned in degrees. Otherwise, they
-            are returned in radians.
+        degrees : bool
+            Whether to return the Euler angles in degrees (`True`) or radians (`False`).
 
         Returns
         -------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -579,7 +579,7 @@ class AidedINS:
         """
         f_imu = np.asarray_chkfinite(f_imu, dtype=float).reshape(3, 1).copy()
         w_imu = np.asarray_chkfinite(w_imu, dtype=float).reshape(3, 1).copy()
-        theta_ext = self.ahrs.attitude(degrees=False)
+        theta_ext = self.ahrs.euler(degrees=False)
 
         if pos is not None:
             pos = np.asarray_chkfinite(pos, dtype=float).reshape(3, 1).copy()

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -166,26 +166,20 @@ class StrapdownINS:
         """
         return self._v.copy()
 
-    def attitude(self, degrees: bool = False) -> NDArray[np.float64]:
+    def euler(self, degrees: bool = False) -> NDArray[np.float64]:
         """
-        Current attitude estimate as vector of Euler angles (i.e., roll, pitch and yaw).
-
-        Given as as:
-
-            ``theta = [alpha, beta, gamma]^T``
-
-        where ``alpha``, ``beta`` and ``gamma`` are the Euler angles (given in radians).
+        Current attitude estimate as Euler angles in ZYX convention, see Notes.
 
         Parameters
         ----------
-        degrees : bool, default False
-            Whether the rotation rates are given in `degrees` (``True``) or `radians`
-            (``False``).
+        degrees : bool
+            Whether to return the attitude in degrees (default) or radians.
 
         Returns
         -------
-        theta : ndarray
-            Attitude as array of shape (3, 1).
+        attitude : ndarray
+            Euler angles, i.e., roll, pitch and yaw (in that order). However, the angles
+            are according to the ZYX convention.
         """
         theta = self._theta.copy()
 
@@ -193,6 +187,12 @@ class StrapdownINS:
             theta = (180.0 / np.pi) * theta
 
         return theta
+
+    def quaternion(self) -> NDArray[np.float64]:
+        """
+        Current attitude estimate as unit quaternion (from-body-to-NED).
+        """
+        return _quaternion_from_euler(self._theta.flatten())
 
     def reset(self, x_new: ArrayLike) -> None:
         """

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -31,7 +31,7 @@ class Test_AHRS:
         assert alg._dt == 1.0 / fs
         assert alg._Kp == Kp
         assert alg._Ki == Ki
-        np.testing.assert_array_almost_equal(alg.q, q_init)
+        np.testing.assert_array_almost_equal(alg.quaternion, q_init)
         np.testing.assert_array_almost_equal(alg.bias, bias_init)
         np.testing.assert_array_almost_equal(alg.error, np.array([0.0, 0.0, 0.0]))
 
@@ -44,7 +44,7 @@ class Test_AHRS:
         alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
 
         q_expect = q_init
-        np.testing.assert_array_almost_equal(alg.q, q_expect)
+        np.testing.assert_array_almost_equal(alg.quaternion, q_expect)
 
     def test_q_init_wrong_len(self):
         fs = 10.24
@@ -73,7 +73,7 @@ class Test_AHRS:
         alg = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
 
         q_expect = np.array([1.0, 0.0, 0.0, 0.0])
-        np.testing.assert_array_almost_equal(alg.q, q_expect)
+        np.testing.assert_array_almost_equal(alg.quaternion, q_expect)
 
     def test_bias_init(self):
         fs = 10.24
@@ -115,13 +115,13 @@ class Test_AHRS:
 
         alpha_beta_gamma = np.array([-30.0, 0.0, 0.0], dtype=float)
         np.testing.assert_array_almost_equal(
-            alg.attitude(), alpha_beta_gamma, decimal=3
+            alg.euler(), alpha_beta_gamma, decimal=3
         )
         np.testing.assert_array_almost_equal(
-            alg.attitude(degrees=True), alpha_beta_gamma, decimal=3
+            alg.euler(degrees=True), alpha_beta_gamma, decimal=3
         )
         np.testing.assert_array_almost_equal(
-            alg.attitude(degrees=False), np.radians(alpha_beta_gamma), decimal=3
+            alg.euler(degrees=False), np.radians(alpha_beta_gamma), decimal=3
         )
 
     def test__update_Ki(self):
@@ -189,7 +189,7 @@ class Test_AHRS:
         error_expect = np.array([0.0, 0.034899, 0.5])
         bias_expect = np.array([0.0, -0.000170, -0.002441])
 
-        np.testing.assert_array_almost_equal(alg.q, q_expect)
+        np.testing.assert_array_almost_equal(alg.quaternion, q_expect)
         np.testing.assert_array_almost_equal(alg.error, error_expect)
         np.testing.assert_array_almost_equal(alg.bias, bias_expect)
 
@@ -220,7 +220,7 @@ class Test_AHRS:
         error_expect = np.array([0.0, 0.0, 0.0])
         bias_expect = np.array([0.0, 0.0, 0.0])
 
-        np.testing.assert_array_almost_equal(alg.q, q_expect)
+        np.testing.assert_array_almost_equal(alg.quaternion, q_expect)
         np.testing.assert_array_almost_equal(alg.error, error_expect)
         np.testing.assert_array_almost_equal(alg.bias, bias_expect)
 
@@ -259,7 +259,7 @@ class Test_AHRS:
 
         alg = _ahrs.AHRS(fs, Kp, Ki)
         _ = [
-            alg.update(f_imu_i, w_imu_i, head_i).q
+            alg.update(f_imu_i, w_imu_i, head_i).quaternion
             for f_imu_i, w_imu_i, head_i in zip(f_imu, w_imu, head)
         ]
 
@@ -280,7 +280,7 @@ class Test_AHRS:
         ahrs = _ahrs.AHRS(fs, Kp, Ki, q_init=q_init)
         euler_out = np.array(
             [
-                ahrs.update(f_imu_i, w_imu_i, head_i).attitude(degrees=True)
+                ahrs.update(f_imu_i, w_imu_i, head_i).euler(degrees=True)
                 for f_imu_i, w_imu_i, head_i in zip(f_imu, w_imu, head)
             ]
         )[600:, :]

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -370,6 +370,14 @@ class Test_AidedINS:
         ).reshape(-1, 1)
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
+    def test_quaternions(self, ains):
+        quaternion_out = ains.quaternion()
+
+        theta_expect = np.array([np.pi / 4, np.pi / 8, np.pi / 16])
+        q_expected = Rotation.from_euler("ZYX", theta_expect[::-1], degrees=False).as_quat()
+        q_expected = np.r_[q_expected[-1], q_expected[0:-1]]  # scipy rearrange
+        np.testing.assert_array_almost_equal(quaternion_out, q_expected)
+
     def test__prep_F_matrix(self):
         err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
         err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -92,23 +92,36 @@ class Test_StrapdownINS:
 
         np.testing.assert_array_almost_equal(v_out, v_expect)
 
-    def test_attitude_rad(self, ins):
+    def test_euler_rad(self, ins):
         x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.pi, np.pi / 2.0, np.pi / 4.0])
         ins.reset(x)
 
-        theta_out = ins.attitude(degrees=False)
+        theta_out = ins.euler(degrees=False)
         theta_expect = np.array([np.pi, np.pi / 2.0, np.pi / 4.0]).reshape(-1, 1)
 
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
-    def test_attitude_deg(self, ins):
+    def test_euler_deg(self, ins):
         x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.pi, np.pi / 2.0, np.pi / 4.0])
         ins.reset(x)
 
-        theta_out = ins.attitude(degrees=True)
+        theta_out = ins.euler(degrees=True)
         theta_expect = np.array([180.0, 90.0, 45.0]).reshape(-1, 1)
 
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
+
+    def test_quaternion(self, ins):
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.pi, np.pi / 2.0, np.pi / 4.0])
+        ins.reset(x)
+
+        quaternion_out = ins.quaternion()
+        q_expected = Rotation.from_euler(
+            "ZYX",
+            np.array([np.pi, np.pi / 2.0, np.pi / 4.0])[::-1],
+            degrees=False
+            ).as_quat()
+        q_expected = np.r_[q_expected[-1], q_expected[:-1]]
+        np.testing.assert_array_almost_equal(quaternion_out, q_expected)
 
     def test_update(self):
         x0 = np.zeros((9, 1))
@@ -370,7 +383,7 @@ class Test_AidedINS:
         ).reshape(-1, 1)
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
-    def test_quaternions(self, ains):
+    def test_quaternion(self, ains):
         quaternion_out = ains.quaternion()
 
         theta_expect = np.array([np.pi / 4, np.pi / 8, np.pi / 16])


### PR DESCRIPTION
### This PR is related to user story DLAB-49

## Description
Rename attitude to euler to ensure consistent naming across ass state estimator classes.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
