### PR TITLE
Flatten state output arrays

### DIFF
--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -201,7 +201,7 @@ class AHRS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes

--- a/src/smsfusion/_ahrs.py
+++ b/src/smsfusion/_ahrs.py
@@ -201,7 +201,7 @@ class AHRS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angles, specifically:  alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -435,7 +435,7 @@ class AidedINS:
                 - Accelerometer bias in x, y, z directions (3 elements).
                 - Gyroscope bias in x, y, z directions (3 elements).
         """
-        return self._x.copy()
+        return self._x.flatten()
 
     def position(self) -> NDArray[np.float64]:
         """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -129,8 +129,8 @@ class StrapdownINS:
 
         Returns
         -------
-        x : ndarray
-            State as array of shape (9, 1).
+        x : numpy.array
+            State as array of shape (9,).
         """
         return self._x.flatten()
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -498,7 +498,7 @@ class AidedINS:
         Passive rotations mean that the frame itself is rotating, not the object
         within the frame.
         """
-        theta = self._theta.copy()
+        theta = self._theta.flatten()
 
         if degrees:
             theta = (180.0 / np.pi) * theta
@@ -508,6 +508,11 @@ class AidedINS:
     def quaternion(self) -> NDArray[np.float64]:
         """
         Current attitude estimate as unit quaternion (from-body-to-NED).
+
+        Returns
+        -------
+        quaternion : numpy.ndarray (3,)
+            The current attitude estimate as a unit quaternion.
         """
         return _quaternion_from_euler(self._theta.flatten())
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -132,7 +132,7 @@ class StrapdownINS:
         x : ndarray
             State as array of shape (9, 1).
         """
-        return self._x.copy()
+        return self._x.flatten()
 
     def position(self) -> NDArray[np.float64]:
         """
@@ -427,7 +427,7 @@ class AidedINS:
 
         Returns
         -------
-        x : ndarray (15, 1)
+        x : numpy.array (15,)
             The current state vector, containing the following elements in order:
                 - Position in x, y, z directions (3 elements).
                 - Velocity in x, y, z directions (3 elements).
@@ -642,7 +642,7 @@ class AidedINS:
             head = np.radians(head)
 
         # Update INS state
-        self._x_ins[0:9] = self._ins.x
+        self._x_ins[0:9] = self._ins.x.reshape(9, 1)
 
         # Setup transformation matrices based on AHRS 'measurement'
         R_bn = _rot_matrix_from_euler(theta_ext)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -449,7 +449,7 @@ class AidedINS:
                 - Position in y direction.
                 - Position in z direction.
         """
-        return self._p.copy()
+        return self._p.flatten()
 
     def velocity(self) -> NDArray[np.float64]:
         """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -182,7 +182,7 @@ class StrapdownINS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -129,8 +129,8 @@ class StrapdownINS:
 
         Returns
         -------
-        x : numpy.array
-            State as array of shape (9,).
+        x : numpy.ndarray
+            State as array of shape (3,).
         """
         return self._x.flatten()
 
@@ -147,10 +147,10 @@ class StrapdownINS:
 
         Returns
         -------
-        p : ndarray
-            Position as array of shape (3, 1).
+        p : numpy.ndarray
+            Position as array of shape (3,).
         """
-        return self._p.copy()
+        return self._p.flatten()
 
     def velocity(self) -> NDArray[np.float64]:
         """
@@ -165,10 +165,10 @@ class StrapdownINS:
 
         Returns
         -------
-        v : ndarray
-            Velocity as array of shape (3, 1).
+        v : numpy.ndarray
+            Velocity as array of shape (3,).
         """
-        return self._v.copy()
+        return self._v.flatten()
 
     def euler(self, degrees: bool = False) -> NDArray[np.float64]:
         """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -427,7 +427,7 @@ class AidedINS:
 
         Returns
         -------
-        x : numpy.array (15,)
+        x : numpy.ndarray (15,)
             The current state vector, containing the following elements in order:
                 - Position in x, y, z directions (3 elements).
                 - Velocity in x, y, z directions (3 elements).
@@ -443,7 +443,7 @@ class AidedINS:
 
         Returns
         -------
-        position : ndarray (3, 1)
+        position : numpy.ndarray (3,)
             The current position vector, containing the following elements:
                 - Position in x direction.
                 - Position in y direction.
@@ -457,13 +457,13 @@ class AidedINS:
 
         Returns
         -------
-        position : ndarray (3, 1)
+        position : numpy.ndarray (3,)
             The current velocity vector, containing the following elements:
                 - Velocity in x direction.
                 - Velocity in y direction.
                 - Velocity in z direction.
         """
-        return self._v.copy()
+        return self._v.flatten()
 
     def euler(self, degrees: bool = False) -> NDArray[np.float64]:
         """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -182,7 +182,7 @@ class StrapdownINS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes
@@ -477,7 +477,7 @@ class AidedINS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angles, specifically:  alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -130,7 +130,7 @@ class StrapdownINS:
         Returns
         -------
         x : numpy.ndarray
-            State as array of shape (3,).
+            State as array of shape (9,).
         """
         return self._x.flatten()
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -182,7 +182,7 @@ class StrapdownINS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angles, specifically:  alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes
@@ -203,7 +203,7 @@ class StrapdownINS:
         Passive rotations mean that the frame itself is rotating, not the object
         within the frame.
         """
-        theta = self._theta.copy()
+        theta = self._theta.flatten()
 
         if degrees:
             theta = (180.0 / np.pi) * theta

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -477,7 +477,7 @@ class AidedINS:
         Returns
         -------
         euler : numpy.ndarray
-            Euler angle vector, specifically: alpha (roll), beta (pitch) and gamma (yaw)
+            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
         Notes

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -145,6 +145,33 @@ class Test_AHRS:
         assert q_out is not q_init
         np.testing.assert_array_almost_equal(q_out, q_expect, decimal=3)
 
+    def test_error(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+        q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
+
+        q_out = alg.error()
+        q_expect = np.zeros(3)
+
+        assert q_out.shape == (3,)
+        np.testing.assert_array_almost_equal(q_out, q_expect, decimal=3)
+
+    def test_bias(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+        bias_init = np.array([0.1, 0.2, 0.3], dtype=float)
+        alg = AHRS(fs, Kp, Ki, bias_init=bias_init)
+
+        bias_out = alg.bias()
+        bias_expect = bias_init
+
+        assert bias_out.shape == (3,)
+        assert bias_out is not bias_init
+        np.testing.assert_array_almost_equal(bias_out, bias_expect, decimal=3)
+
     def test__update_Ki(self):
         dt = 0.1
         q = np.array([1.0, 0.0, 0.0, 0.0])

--- a/tests/test_ahrs.py
+++ b/tests/test_ahrs.py
@@ -122,6 +122,29 @@ class Test_AHRS:
             alg.euler(degrees=False), np.radians(alpha_beta_gamma), decimal=3
         )
 
+    def test_attitude_shape(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+        q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
+
+        alg.euler().shape == (3,)
+
+    def test_quaternion(self):
+        fs = 10.24
+        Kp = 0.5
+        Ki = 0.1
+        q_init = np.array([0.96591925, -0.25882081, 0.0, 0.0], dtype=float)
+        alg = AHRS(fs, Kp, Ki, q_init=q_init)
+
+        q_out = alg.quaternion()
+        q_expect = q_init
+
+        assert q_out.shape == (4,)
+        assert q_out is not q_init
+        np.testing.assert_array_almost_equal(q_out, q_expect, decimal=3)
+
     def test__update_Ki(self):
         dt = 0.1
         q = np.array([1.0, 0.0, 0.0, 0.0])

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -375,8 +375,11 @@ class Test_AidedINS:
                 0.005,
                 0.006,
             ]
-        ).reshape(-1, 1)
+        )
         x_out = ains.x
+
+        assert x_out.shape == (15,)
+        assert x_out is not ains._x
         np.testing.assert_array_almost_equal(x_out, x_expect)
         assert x_out is not ains._x
 
@@ -515,9 +518,9 @@ class Test_AidedINS:
         pos = np.zeros(3)
 
         ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)
-        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        np.testing.assert_array_almost_equal(ains.x, np.zeros(15))
         ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)
-        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        np.testing.assert_array_almost_equal(ains.x, np.zeros(15))
 
     def test_update_irregular_position_aiding(self):
         fs = 10.24
@@ -538,11 +541,11 @@ class Test_AidedINS:
         pos = np.zeros(3)
 
         ains.update(f_imu, w_imu, head, None, degrees=True, head_degrees=True)  # no pos
-        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        np.testing.assert_array_almost_equal(ains.x, np.zeros(15))
         ains.update(f_imu, w_imu, head, pos, degrees=True, head_degrees=True)  # pos
-        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        np.testing.assert_array_almost_equal(ains.x, np.zeros(15))
         ains.update(f_imu, w_imu, head, degrees=True, head_degrees=True)  # no pos
-        np.testing.assert_array_almost_equal(ains.x, np.zeros((15, 1)))
+        np.testing.assert_array_almost_equal(ains.x, np.zeros(15))
 
     def test_update_reference_case(self, ains_ref_data):
         """Test that succesive calls goes through"""

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -386,11 +386,17 @@ class Test_AidedINS:
     def test_position(self, ains):
         pos_out = ains.position()
         pos_expect = np.array([1.0, 2.0, 3.0])
+
+        assert pos_out.shape == (3,)
+        assert pos_out is not ains._p
         np.testing.assert_array_almost_equal(pos_out, pos_expect)
 
     def test_velocity(self, ains):
         vel_out = ains.velocity()
-        vel_expect = np.array([0.1, 0.2, 0.3]).reshape(-1, 1)
+        vel_expect = np.array([0.1, 0.2, 0.3])
+
+        assert vel_out.shape == (3,)
+        assert vel_out is not ains._v
         np.testing.assert_array_almost_equal(vel_out, vel_expect)
 
     def test_euler_radians(self, ains):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -385,7 +385,7 @@ class Test_AidedINS:
 
     def test_position(self, ains):
         pos_out = ains.position()
-        pos_expect = np.array([1.0, 2.0, 3.0]).reshape(-1, 1)
+        pos_expect = np.array([1.0, 2.0, 3.0])
         np.testing.assert_array_almost_equal(pos_out, pos_expect)
 
     def test_velocity(self, ains):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -74,6 +74,7 @@ class Test_StrapdownINS:
         x_expect = x
 
         assert x_out.shape == (9,)
+        assert x_out is not ins._x
         np.testing.assert_array_equal(x_out, x_expect)
 
     def test_position(self, ins):
@@ -81,6 +82,7 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         p_out = ins.position()
+        assert p_out is not ins._p
         p_expect = np.array([1.0, 2.0, 3.0])
 
         assert p_out.shape == (3,)
@@ -91,6 +93,7 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         v_out = ins.velocity()
+        assert v_out is not ins._v
         v_expect = np.array([4.0, 5.0, 6.0])
 
         assert v_out.shape == (3,)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -72,6 +72,8 @@ class Test_StrapdownINS:
 
         x_out = ins.x
         x_expect = x
+
+        assert x_out.shape == (9,)
         np.testing.assert_array_equal(x_out, x_expect)
 
     def test_position(self, ins):
@@ -79,8 +81,9 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         p_out = ins.position()
-        p_expect = np.array([1.0, 2.0, 3.0]).reshape(-1, 1)
+        p_expect = np.array([1.0, 2.0, 3.0])
 
+        assert p_out.shape == (3,)
         np.testing.assert_array_almost_equal(p_out, p_expect)
 
     def test_velocity(self, ins):
@@ -88,8 +91,9 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         v_out = ins.velocity()
-        v_expect = np.array([4.0, 5.0, 6.0]).reshape(-1, 1)
+        v_expect = np.array([4.0, 5.0, 6.0])
 
+        assert v_out.shape == (3,)
         np.testing.assert_array_almost_equal(v_out, v_expect)
 
     def test_euler_rad(self, ins):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -401,14 +401,20 @@ class Test_AidedINS:
 
     def test_euler_radians(self, ains):
         theta_out = ains.euler(degrees=False)
-        theta_expect = np.array([np.pi / 4, np.pi / 8, np.pi / 16]).reshape(-1, 1)
+        theta_expect = np.array([np.pi / 4, np.pi / 8, np.pi / 16])
+
+        assert theta_out.shape == (3,)
+        assert theta_out is not ains._theta
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
     def test_euler_degrees(self, ains):
         theta_out = ains.euler(degrees=True)
         theta_expect = (180.0 / np.pi) * np.array(
             [np.pi / 4, np.pi / 8, np.pi / 16]
-        ).reshape(-1, 1)
+        )
+
+        assert theta_out.shape == (3,)
+        assert theta_out is not ains._theta
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
     def test_quaternion(self, ains):
@@ -419,6 +425,8 @@ class Test_AidedINS:
             "ZYX", theta_expect[::-1], degrees=False
         ).as_quat()
         q_expected = np.r_[q_expected[-1], q_expected[0:-1]]  # scipy rearrange
+
+        assert quaternion_out.shape == (4,)
         np.testing.assert_array_almost_equal(quaternion_out, q_expected)
 
     def test__prep_F_matrix(self):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -130,6 +130,8 @@ class Test_StrapdownINS:
             "ZYX", np.array([np.pi, np.pi / 2.0, np.pi / 4.0])[::-1], degrees=False
         ).as_quat()
         q_expected = np.r_[q_expected[-1], q_expected[:-1]]
+
+        assert quaternion_out.shape == (4,)
         np.testing.assert_array_almost_equal(quaternion_out, q_expected)
 
     def test_update_return_self(self):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -160,9 +160,7 @@ class Test_StrapdownINS:
         x1_out = ins.x
 
         x0_expect = np.zeros(9)
-        x1_expect = np.array(
-            [0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
-        )
+        x1_expect = np.array([0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect)
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
@@ -409,9 +407,7 @@ class Test_AidedINS:
 
     def test_euler_degrees(self, ains):
         theta_out = ains.euler(degrees=True)
-        theta_expect = (180.0 / np.pi) * np.array(
-            [np.pi / 4, np.pi / 8, np.pi / 16]
-        )
+        theta_expect = (180.0 / np.pi) * np.array([np.pi / 4, np.pi / 8, np.pi / 16])
 
         assert theta_out.shape == (3,)
         assert theta_out is not ains._theta

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -104,8 +104,10 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         theta_out = ins.euler(degrees=False)
-        theta_expect = np.array([np.pi, np.pi / 2.0, np.pi / 4.0]).reshape(-1, 1)
+        theta_expect = np.array([np.pi, np.pi / 2.0, np.pi / 4.0])
 
+        assert theta_out.shape == (3,)
+        assert theta_out is not ins._theta
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
     def test_euler_deg(self, ins):
@@ -113,8 +115,10 @@ class Test_StrapdownINS:
         ins.reset(x)
 
         theta_out = ins.euler(degrees=True)
-        theta_expect = np.array([180.0, 90.0, 45.0]).reshape(-1, 1)
+        theta_expect = np.array([180.0, 90.0, 45.0])
 
+        assert theta_out.shape == (3,)
+        assert theta_out is not ins._theta
         np.testing.assert_array_almost_equal(theta_out, theta_expect)
 
     def test_quaternion(self, ins):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -67,7 +67,7 @@ class Test_StrapdownINS:
         np.testing.assert_array_equal(ins._x, x)
 
     def test_x(self, ins):
-        x = np.random.random((9, 1))
+        x = np.random.random(9)
         ins.reset(x)
 
         x_out = ins.x
@@ -146,10 +146,10 @@ class Test_StrapdownINS:
         ins.update(h, f, w)
         x1_out = ins.x
 
-        x0_expect = np.zeros((9, 1))
+        x0_expect = np.zeros(9)
         x1_expect = np.array(
             [0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
-        ).reshape(-1, 1)
+        )
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect)
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
@@ -167,7 +167,7 @@ class Test_StrapdownINS:
         ins.update(dt, f_imu, w_imu, degrees=True)
         x1_out = ins.x
 
-        x0_expect = np.zeros((9, 1))
+        x0_expect = np.zeros(9)
         x1_expect = np.array(
             [
                 0.005,
@@ -180,7 +180,7 @@ class Test_StrapdownINS:
                 (np.pi / 180.0) * 0.5,
                 (np.pi / 180.0) * 0.6,
             ]
-        ).reshape(-1, 1)
+        )
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect)
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
@@ -224,9 +224,9 @@ class Test_StrapdownINS:
         x2_expect[3:6] = x1_expect[3:6] + dt * a1_expect
         x2_expect[6:9] = x1_expect[6:9] + dt * T1_expect @ w_imu
 
-        np.testing.assert_array_almost_equal(x0_out, x0_expect)
-        np.testing.assert_array_almost_equal(x1_out, x1_expect)
-        np.testing.assert_array_almost_equal(x2_out, x2_expect)
+        np.testing.assert_array_almost_equal(x0_out, x0_expect.flatten())
+        np.testing.assert_array_almost_equal(x1_out, x1_expect.flatten())
+        np.testing.assert_array_almost_equal(x2_out, x2_expect.flatten())
 
     def test_update_R_T(self):
         ins = StrapdownINS(np.zeros((9, 1)))
@@ -238,17 +238,13 @@ class Test_StrapdownINS:
         ins.update(h, f_imu, w_imu, theta_ext=(0.0, 0.0, 0.0))
 
         x_out = ins.x
-        x_expect = np.array([0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]).reshape(
-            -1, 1
-        )
+        x_expect = np.array([0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
         np.testing.assert_array_almost_equal(x_out, x_expect)
 
         ins.update(h, f_imu, w_imu, theta_ext=(0.0, 0.0, 0.0))
 
         x_out = ins.x
-        x_expect = np.array([0.02, 0.04, 0.06, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2]).reshape(
-            -1, 1
-        )
+        x_expect = np.array([0.02, 0.04, 0.06, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2])
         np.testing.assert_array_almost_equal(x_out, x_expect)
 
 


### PR DESCRIPTION
### This PR is related to user story DLAB-47

## Description
Flatten all state output arrays.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
