### PR TITLE
Beating and chirp signal generators return the second time derivative

### DIFF
--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -8,7 +8,7 @@ from numpy.typing import ArrayLike, NDArray
 
 class _Signal(abc.ABC):
     """
-    Abstarct class for benchmark signals.
+    Abstract class for benchmark signals.
     """
 
     def __call__(

--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -44,11 +44,15 @@ class _Signal(abc.ABC):
         return self._y(t, phase), self._dydt(t, phase), self._d2ydt2(t, phase)
 
     @abc.abstractmethod
-    def _y(self):
+    def _y(self, t: NDArray[np.float64], phase: float) -> NDArray[np.float64]:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _dydt(self):
+    def _dydt(self, t: NDArray[np.float64], phase: float) -> NDArray[np.float64]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _d2ydt2(self, t: NDArray[np.float64], phase: float) -> NDArray[np.float64]:
         raise NotImplementedError
 
 
@@ -111,7 +115,6 @@ class BeatSignal(_Signal):
         dydt = dbeat * main + beat * dmain
         return dydt  # type: ignore[no-any-return]
 
-    #TODO: Verify!
     def _d2ydt2(self, t: NDArray[np.float64], phase: float) -> NDArray[np.float64]:
         """
         Generate the second time derivative of a beating signal with a unit
@@ -121,8 +124,8 @@ class BeatSignal(_Signal):
         beat = np.sin(self._f_beat / 2.0 * t)
         dmain = -self._f_main * np.sin(self._f_main * t + phase)
         dbeat = self._f_beat / 2.0 * np.cos(self._f_beat / 2.0 * t)
-        d2main = -(self._f_main)**2 * np.cos(self._f_main * t + phase)
-        d2beat = -(self._f_beat / 2.0)**2 * np.sin(self._f_beat / 2.0 * t)
+        d2main = -((self._f_main) ** 2) * np.cos(self._f_main * t + phase)
+        d2beat = -((self._f_beat / 2.0) ** 2) * np.sin(self._f_beat / 2.0 * t)
 
         d2ydt2 = dbeat * dmain + d2beat * main + beat * d2main + dbeat * dmain
 
@@ -192,6 +195,6 @@ class ChirpSignal(_Signal):
         """
         phi = 2.0 * self._f_max / self._f_os * np.sin(self._f_os / 2.0 * t)
         dphi = self._f_max * np.cos(self._f_os / 2.0 * t)
-        d2phi = - self._f_max * self._f_os / 2.0 * np.sin(self._f_os / 2.0 * t)
-        d2ydt2 = -dphi**2 * np.sin(phi + phase) + d2phi * np.cos(phi + phase)
+        d2phi = -self._f_max * self._f_os / 2.0 * np.sin(self._f_os / 2.0 * t)
+        d2ydt2 = -(dphi**2) * np.sin(phi + phase) + d2phi * np.cos(phi + phase)
         return d2ydt2  # type: ignore[no-any-return]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -21,11 +21,12 @@ class Test_BeatSignal:
         fs = 10.0
         n = 2000
         t = np.linspace(0.0, n / fs, n, endpoint=False)
-        y, dydt = beat_signal(t)
+        y, dydt, d2ydt2 = beat_signal(t)
 
         assert len(t) == int(n)
         assert len(t) == len(y)
         assert len(t) == len(dydt)
+        assert len(t) == len(d2ydt2)
 
         assert t[0] == 0.0
         assert t[-1] == pytest.approx((n - 1) / fs)
@@ -38,6 +39,15 @@ class Test_BeatSignal:
         np.testing.assert_allclose(
             dydt[1:-1], np.gradient(y, t)[1:-1], atol=0.0025
         )  # Verified tolerance
+
+        np.testing.assert_allclose(
+            d2ydt2[1:-1], np.gradient(dydt, t)[1:-1], atol=0.0025
+        )  # Verified tolerance
+
+        y_phase, dydt_phase, d2ydt2_phase = beat_signal(t, phase=30.0)
+        assert not np.array_equal(y, y_phase)
+        assert not np.array_equal(dydt, dydt_phase)
+        assert not np.array_equal(d2ydt2, d2ydt2_phase)
 
 
 class Test_ChirpSignal:
@@ -57,7 +67,7 @@ class Test_ChirpSignal:
         fs = 10.0
         n = 10_000
         t = np.linspace(0.0, n / fs, n, endpoint=False)
-        y, dydt = chirp_signal(t)
+        y, dydt, d2ydt2 = chirp_signal(t)
 
         assert len(t) == int(n)
         assert len(t) == len(y)
@@ -75,6 +85,11 @@ class Test_ChirpSignal:
             dydt[1:-1], np.gradient(y, t)[1:-1], atol=0.0025
         )  # Verified tolerance
 
-        y_phase, dydt_phase = chirp_signal(t, phase=30.0)
+        np.testing.assert_allclose(
+            d2ydt2[1:-1], np.gradient(dydt, t)[1:-1], atol=0.0025
+        )  # Verified tolerance
+
+        y_phase, dydt_phase, d2ydt2_phase = chirp_signal(t, phase=30.0)
         assert not np.array_equal(y, y_phase)
         assert not np.array_equal(dydt, dydt_phase)
+        assert not np.array_equal(d2ydt2, d2ydt2_phase)


### PR DESCRIPTION
### This PR is related to user story DLAB-58 and DLAB-59

## Description
Added a new method for returning the second time derivative for BeatSignal and ChirpSignal.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
