### PR TITLE
Add standardized benchmark tests for AHRS

### DIFF
--- a/src/smsfusion/benchmark/__init__.py
+++ b/src/smsfusion/benchmark/__init__.py
@@ -1,3 +1,15 @@
-from ._benchmark import BeatSignal, ChirpSignal, _benchmark_helper
+from ._benchmark import (
+    BeatSignal,
+    ChirpSignal,
+    _benchmark_helper,
+    benchmark_ahrs_beat_202311A,
+    benchmark_ahrs_chirp_202311A,
+)
 
-__all__ = ["_benchmark_helper", "BeatSignal", "ChirpSignal"]
+__all__ = [
+    "_benchmark_helper",
+    "BeatSignal",
+    "benchmark_ahrs_beat_202311A",
+    "benchmark_ahrs_chirp_202311A",
+    "ChirpSignal",
+]

--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -349,3 +349,126 @@ def _benchmark_helper(
         np.asarray(accelerometer),
         np.asarray(gyroscope),
     )
+
+
+def benchmark_ahrs_beat_202311A(fs: float = 10.24):
+    """
+    A benchmark for performance testing of AHRS sensor fusion algorithms.
+
+    The benchmark scenario is 20 minutes long. It generates Euler angles
+    (roll, pitch, and yaw), and the corresponding accelerometer and
+    gyroscope signals. Note that the generated motion is pure rotations.
+
+    The generated signals are "beating" with maximum amplitudes corresponding to
+    5 degrees. The main signal frequency is 0.1 Hz while the "beating" frequency
+    is 0.01 Hz. The phases for roll, pitch, and yaw are 0.0, 45.0, and 90.0 degrees
+    respectively. See ``BeatSignal`` for details.
+
+    Parameters
+    ----------
+    fs : float, default 10.24
+        Sampling frequency of the generated signals.
+
+    Returns
+    -------
+    t : numpy.ndarray, shape (N,)
+        Time in seconds.
+    euler : numpy.ndarray, shape (N, 3)
+        Attitude of the body in Euler angles [rad], see Notes.
+    acc : numpy.ndarray, shape (N, 3)
+        Accelerations [m/s**2] in body frame (corresponding to accelerometer measurements).
+    gyro : numpy.ndarray, shape (N, 3)
+        Angular rates [rad/s] in body frame (corresponding to gyroscope measurements).
+
+    Notes
+    -----
+    The Euler angles describe how to transition from the 'NED' frame to the 'body'
+    frame through three consecutive intrinsic and passive rotations in the ZYX order:
+        1. A rotation by an angle gamma (often called yaw) about the z-axis.
+        2. A subsequent rotation by an angle beta (often called pitch) about the y-axis.
+        3. A final rotation by an angle alpha (often called roll) about the x-axis.
+
+    This sequence of rotations is used to describe the orientation of the 'body' frame
+    relative to the 'NED' frame in 3D space.
+
+    Intrinsic rotations mean that the rotations are with respect to the changing
+    coordinate system; as one rotation is applied, the next is about the axis of
+    the newly rotated system.
+
+    Passive rotations mean that the frame itself is rotating, not the object
+    within the frame.
+
+    """
+    duration = 1200.0  # 20 minutes
+    amplitude = (0.0, 0.0, 0.0, 5.0, 5.0, 5.0)
+    mean = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
+
+    f_main = 0.1
+    f_beat = 0.01
+
+    t, _, _, euler, acc, gyro = _benchmark_helper(
+        duration, amplitude, mean, phase, BeatSignal(f_main, f_beat), fs
+    )
+    return t, euler, acc, gyro
+
+
+def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
+    """
+    A benchmark for performance testing of AHRS sensor fusion algorithms.
+
+    The benchmark scenario is 20 minutes long. It generates Euler angles
+    (roll, pitch, and yaw), and the corresponding accelerometer and
+    gyroscope signals. Note that the generated motion is pure rotations.
+
+    The generated signals have a frequency that appears to vary in time and
+    amplitudes corresponding to 5 degrees. The phases for roll, pitch, and yaw
+    are 0.0, 45.0, and 90.0 degrees respectively. See ``ChirpSignal`` for details.
+
+    Parameters
+    ----------
+    fs : float, default 10.24
+        Sampling frequency of the generated signals.
+
+    Returns
+    -------
+    t : numpy.ndarray, shape (N,)
+        Time in seconds.
+    euler : numpy.ndarray, shape (N, 3)
+        Attitude of the body in Euler angles [rad], see Notes.
+    acc : numpy.ndarray, shape (N, 3)
+        Accelerations [m/s**2] in body frame (corresponding to accelerometer measurements).
+    gyro : numpy.ndarray, shape (N, 3)
+        Angular rates [rad/s] in body frame (corresponding to gyroscope measurements).
+
+    Notes
+    -----
+    The Euler angles describe how to transition from the 'NED' frame to the 'body'
+    frame through three consecutive intrinsic and passive rotations in the ZYX order:
+        1. A rotation by an angle gamma (often called yaw) about the z-axis.
+        2. A subsequent rotation by an angle beta (often called pitch) about the y-axis.
+        3. A final rotation by an angle alpha (often called roll) about the x-axis.
+
+    This sequence of rotations is used to describe the orientation of the 'body' frame
+    relative to the 'NED' frame in 3D space.
+
+    Intrinsic rotations mean that the rotations are with respect to the changing
+    coordinate system; as one rotation is applied, the next is about the axis of
+    the newly rotated system.
+
+    Passive rotations mean that the frame itself is rotating, not the object
+    within the frame.
+
+    """
+    duration = 1200.0  # 20 minutes
+    amplitude = (0.0, 0.0, 0.0, 5.0, 5.0, 5.0)
+    mean = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
+
+    f_main = 0.1
+    f_beat = 0.01
+
+    t, _, _, euler, acc, gyro = _benchmark_helper(
+        duration, amplitude, mean, phase, ChirpSignal(f_main, f_beat), fs
+    )
+    return t, euler, acc, gyro

--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -422,8 +422,10 @@ def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
     gyroscope signals. Note that the generated motion is pure rotations.
 
     The generated signals have a frequency that appears to vary in time and
-    amplitudes corresponding to 5 degrees. The phases for roll, pitch, and yaw
-    are 0.0, 45.0, and 90.0 degrees respectively. See ``ChirpSignal`` for details.
+    amplitudes corresponding to 5 degrees. The signal frequency oscillates
+    between 0.0 Hz and 0.25 Hz every 100 seconds. The phases for roll, pitch,
+    and yaw are 0.0, 45.0, and 90.0 degrees respectively. See ``ChirpSignal``
+    for details.
 
     Parameters
     ----------
@@ -465,10 +467,10 @@ def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
     mean = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
 
-    f_main = 0.1
-    f_beat = 0.01
+    f_max = 0.25
+    f_os = 0.01
 
     t, _, _, euler, acc, gyro = _benchmark_helper(
-        duration, amplitude, mean, phase, ChirpSignal(f_main, f_beat), fs
+        duration, amplitude, mean, phase, ChirpSignal(f_max, f_os), fs
     )
     return t, euler, acc, gyro

--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -351,7 +351,11 @@ def _benchmark_helper(
     )
 
 
-def benchmark_ahrs_beat_202311A(fs: float = 10.24):
+def benchmark_ahrs_beat_202311A(
+    fs: float = 10.24,
+) -> tuple[
+    NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]
+]:
     """
     A benchmark for performance testing of AHRS sensor fusion algorithms.
 
@@ -400,9 +404,9 @@ def benchmark_ahrs_beat_202311A(fs: float = 10.24):
 
     """
     duration = 1200.0  # 20 minutes
-    amplitude = np.radians((0.0, 0.0, 0.0, 5.0, 5.0, 5.0))
-    mean = np.radians((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
-    phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
+    amplitude = np.radians(np.array([0.0, 0.0, 0.0, 5.0, 5.0, 5.0]))
+    mean = np.radians(np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    phase = np.radians(np.array([0.0, 0.0, 0.0, 0.0, 45.0, 90.0]))
 
     f_main = 0.1
     f_beat = 0.01
@@ -413,7 +417,11 @@ def benchmark_ahrs_beat_202311A(fs: float = 10.24):
     return t, euler, acc, gyro
 
 
-def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
+def benchmark_ahrs_chirp_202311A(
+    fs: float = 10.24,
+) -> tuple[
+    NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]
+]:
     """
     A benchmark for performance testing of AHRS sensor fusion algorithms.
 
@@ -463,9 +471,9 @@ def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
 
     """
     duration = 1200.0  # 20 minutes
-    amplitude = np.radians((0.0, 0.0, 0.0, 5.0, 5.0, 5.0))
-    mean = np.radians((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
-    phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
+    amplitude = np.radians(np.array([0.0, 0.0, 0.0, 5.0, 5.0, 5.0]))
+    mean = np.radians(np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    phase = np.radians(np.array([0.0, 0.0, 0.0, 0.0, 45.0, 90.0]))
 
     f_max = 0.25
     f_os = 0.01

--- a/src/smsfusion/benchmark/_benchmark.py
+++ b/src/smsfusion/benchmark/_benchmark.py
@@ -400,8 +400,8 @@ def benchmark_ahrs_beat_202311A(fs: float = 10.24):
 
     """
     duration = 1200.0  # 20 minutes
-    amplitude = (0.0, 0.0, 0.0, 5.0, 5.0, 5.0)
-    mean = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    amplitude = np.radians((0.0, 0.0, 0.0, 5.0, 5.0, 5.0))
+    mean = np.radians((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
     phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
 
     f_main = 0.1
@@ -463,8 +463,8 @@ def benchmark_ahrs_chirp_202311A(fs: float = 10.24):
 
     """
     duration = 1200.0  # 20 minutes
-    amplitude = (0.0, 0.0, 0.0, 5.0, 5.0, 5.0)
-    mean = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    amplitude = np.radians((0.0, 0.0, 0.0, 5.0, 5.0, 5.0))
+    mean = np.radians((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
     phase = np.radians((0.0, 0.0, 0.0, 0.0, 45.0, 90.0))
 
     f_max = 0.25

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -316,7 +316,7 @@ def test_benchmark_ahrs_beat_202311A():
 
 
 def test_benchmark_ahrs_chirp_202311A():
-    signature_signal, _, _ = benchmark.ChirpSignal(0.1, 0.01)(
+    signature_signal, _, _ = benchmark.ChirpSignal(0.25, 0.01)(
         np.arange(0.0, 1200.0, 1.0 / 10.24)
     )
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -298,3 +298,33 @@ class Test__benchmark_helper:
         np.testing.assert_allclose(gyro[:, 0], np.zeros_like(t))
         np.testing.assert_allclose(gyro[:, 1], np.zeros_like(t))
         np.testing.assert_allclose(gyro[:, 2], np.zeros_like(t))
+
+
+def test_benchmark_ahrs_beat_202311A():
+    signature_signal, _, _ = benchmark.BeatSignal(0.1, 0.01)(
+        np.arange(0.0, 1200.0, 1.0 / 10.24)
+    )
+
+    t, euler, acc, gyro = benchmark.benchmark_ahrs_beat_202311A()
+
+    assert len(t) == int(1200 * 10.24)
+    assert euler.shape == (len(t), 3)
+    assert acc.shape == (len(t), 3)
+    assert gyro.shape == (len(t), 3)
+
+    np.testing.assert_array_equal(euler[:, 0], 5.0 * signature_signal)
+
+
+def test_benchmark_ahrs_chirp_202311A():
+    signature_signal, _, _ = benchmark.ChirpSignal(0.1, 0.01)(
+        np.arange(0.0, 1200.0, 1.0 / 10.24)
+    )
+
+    t, euler, acc, gyro = benchmark.benchmark_ahrs_chirp_202311A()
+
+    assert len(t) == int(1200 * 10.24)
+    assert euler.shape == (len(t), 3)
+    assert acc.shape == (len(t), 3)
+    assert gyro.shape == (len(t), 3)
+
+    np.testing.assert_array_equal(euler[:, 0], 5.0 * signature_signal)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -312,7 +312,7 @@ def test_benchmark_ahrs_beat_202311A():
     assert acc.shape == (len(t), 3)
     assert gyro.shape == (len(t), 3)
 
-    np.testing.assert_array_equal(euler[:, 0], 5.0 * signature_signal)
+    np.testing.assert_array_equal(euler[:, 0], np.radians(5.0) * signature_signal)
 
 
 def test_benchmark_ahrs_chirp_202311A():
@@ -327,4 +327,4 @@ def test_benchmark_ahrs_chirp_202311A():
     assert acc.shape == (len(t), 3)
     assert gyro.shape == (len(t), 3)
 
-    np.testing.assert_array_equal(euler[:, 0], 5.0 * signature_signal)
+    np.testing.assert_array_equal(euler[:, 0], np.radians(5.0) * signature_signal)


### PR DESCRIPTION
### This PR is related to user story DLAB-61

## Description
Add AHRS specific benchmark functions.
Include benchmark signals in unit-tests.
Deprecate old "reference case tests"

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
