### PR TITLE
Add private function for calculating signed smallest angle

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -12,12 +12,12 @@ from ._transforms import (
 )
 
 
-def _signed_smallest_angle(angle : float, degrees : bool = True) -> float:
+def _signed_smallest_angle(angle: float, degrees: bool = True) -> float:
     """
     Return the signed smallest angles between [-pi, pi) or [-180, 180) (default).
     """
-    base = 180. if degrees else np.pi
-    return (angle + base) % (2. * base) - base
+    base = 180.0 if degrees else np.pi
+    return (angle + base) % (2.0 * base) - base
 
 
 def gravity(lat: float | None = None, degrees: bool = True) -> float:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -12,6 +12,14 @@ from ._transforms import (
 )
 
 
+def _signed_smallest_angle(angle, degrees=True):
+    """
+    Return the signed smallest angles between [-pi, pi) or [-180, 180) (default).
+    """
+    base = 180. if degrees else np.pi
+    return (angle + base) % (2. * base) - base
+
+
 def gravity(lat: float | None = None, degrees: bool = True) -> float:
     """
     Calculates the gravitational acceleration based on the World Geodetic System

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -12,7 +12,7 @@ from ._transforms import (
 )
 
 
-def _signed_smallest_angle(angle, degrees=True):
+def _signed_smallest_angle(angle : float, degrees : bool = True) -> float:
     """
     Return the signed smallest angles between [-pi, pi) or [-180, 180) (default).
     """

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -15,7 +15,7 @@ import pytest
 from pandas import read_parquet
 from scipy.spatial.transform import Rotation
 
-from smsfusion._ins import AHRS, AidedINS, StrapdownINS, gravity, _signed_smallest_angle
+from smsfusion._ins import AHRS, AidedINS, StrapdownINS, _signed_smallest_angle, gravity
 from smsfusion._transforms import (
     _angular_matrix_from_euler,
     _quaternion_from_euler,
@@ -26,20 +26,19 @@ from smsfusion._transforms import (
 @pytest.mark.parametrize(
     "angle, degrees, angle_expect",
     [
-        (0., True, 0.),
-        (-180.0, True, -180.),
-        (180.0, True, -180.),
+        (0.0, True, 0.0),
+        (-180.0, True, -180.0),
+        (180.0, True, -180.0),
         (-np.pi, False, -np.pi),
         (np.pi, False, -np.pi),
-        (90., True, 90.),
-        (-90., True, -90.),
-        (181, True, -179.),
-        (-181, True, 179.)
+        (90.0, True, 90.0),
+        (-90.0, True, -90.0),
+        (181, True, -179.0),
+        (-181, True, 179.0),
     ],
 )
 def test__signed_smallest_angle(angle, degrees, angle_expect):
     assert _signed_smallest_angle(angle, degrees=degrees) == pytest.approx(angle_expect)
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -15,12 +15,31 @@ import pytest
 from pandas import read_parquet
 from scipy.spatial.transform import Rotation
 
-from smsfusion._ins import AHRS, AidedINS, StrapdownINS, gravity
+from smsfusion._ins import AHRS, AidedINS, StrapdownINS, gravity, _signed_smallest_angle
 from smsfusion._transforms import (
     _angular_matrix_from_euler,
     _quaternion_from_euler,
     _rot_matrix_from_euler,
 )
+
+
+@pytest.mark.parametrize(
+    "angle, degrees, angle_expect",
+    [
+        (0., True, 0.),
+        (-180.0, True, -180.),
+        (180.0, True, -180.),
+        (-np.pi, False, -np.pi),
+        (np.pi, False, -np.pi),
+        (90., True, 90.),
+        (-90., True, -90.),
+        (181, True, -179.),
+        (-181, True, 179.)
+    ],
+)
+def test__signed_smallest_angle(angle, degrees, angle_expect):
+    assert _signed_smallest_angle(angle, degrees=degrees) == pytest.approx(angle_expect)
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### This PR is related to user story DLAB-68

## Description
Add function for calculating signed smallest angle between [-180, 180) or [-pi, -pi), given an angle.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
