### PR TITLE
Add private skew symmetric matrix for cross product operations 

### DIFF
--- a/src/smsfusion/_vectorops.py
+++ b/src/smsfusion/_vectorops.py
@@ -23,3 +23,17 @@ def _cross(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64
             a[0] * b[1] - a[1] * b[0],
         ]
     )
+
+
+@njit  # type: ignore[misc]
+def _skew_symmetric(a: NDArray[np.float64]) -> NDArray[np.float64]:
+    """
+    Cross product equivalent skew symmetric matrix from a vector.
+    """
+    return np.array(
+        [
+            [0., -a[2], a[1]],
+            [a[2], 0., -a[0]],
+            [-a[1], a[0], 0.]
+        ]
+    )

--- a/src/smsfusion/_vectorops.py
+++ b/src/smsfusion/_vectorops.py
@@ -30,10 +30,4 @@ def _skew_symmetric(a: NDArray[np.float64]) -> NDArray[np.float64]:
     """
     Cross product equivalent skew symmetric matrix from a vector.
     """
-    return np.array(
-        [
-            [0., -a[2], a[1]],
-            [a[2], 0., -a[0]],
-            [-a[1], a[0], 0.]
-        ]
-    )
+    return np.array([[0.0, -a[2], a[1]], [a[2], 0.0, -a[0]], [-a[1], a[0], 0.0]])

--- a/tests/test_vectorops.py
+++ b/tests/test_vectorops.py
@@ -23,3 +23,17 @@ def test__cross():
 
     expected = np.cross(a, b)
     np.testing.assert_array_equal(out, expected)
+
+
+def test__skew_symmetric():
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    out = _vectorops._skew_symmetric(a) @ b
+    expected = np.array([0.0, 0.0, 1.0])
+    np.testing.assert_array_equal(out, expected)
+
+    a = np.array([1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0), 0.0])
+    b = np.array([0.0, 1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0)])
+    out = _vectorops._skew_symmetric(a) @ b
+    expected = np.cross(a, b)
+    np.testing.assert_array_equal(out, expected)


### PR DESCRIPTION
### This PR is related to user story DLAB-70

## Description
Add a private function that return skew symmetric matrix for cross product operations.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
