### PR TITLE
Strapdown algorithm using quaternions

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -75,21 +75,15 @@ class StrapdownINS:
 
     Parameters
     ----------
-    x0 : array_like
-        Initial state vector as 1D array of length 10 (see Notes).
+    x0 : numpy.ndarray (10,)
+        Initial state vector, containing the following elements in order:
+            - Position in x-, y-, and z-direction (3 elements).
+            - Velocity in x-, y-, and z-direction (3 elements).
+            - Attitude as unit quaternion (4 elements). Should be given as [q1, q2, q3, q4],
+              where q1 is the real part and q1, q2 and q3 are the three imaginary parts.
     lat : float, optional
         Latitude used to calculate the gravitational acceleration. If `lat` is ``None``,
         the 'standard gravity' (i.e., 9.80665) is used.
-
-    Notes
-    -----
-    The state vector should be given as:
-
-        ``x = [p_x, p_y, p_z, v_x, v_y, v_z, alpha, beta, gamma]^T``
-
-    where ``p_x``, ``p_y`` and ``p_z`` are position coordinates (in x-, y- and z-direction),
-    ``v_x``, ``v_y`` and ``v_z`` are (linear) velocities (in x-, y- and z-direction),
-    and ``alpha``, ``beta`` and ``gamma`` are Euler angles (given in radians).
     """
 
     def __init__(self, x0: ArrayLike, lat: float | None = None) -> None:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -475,7 +475,9 @@ class _LegacyStrapdownINS:
         w_imu: ArrayLike,
         degrees: bool = False,
         theta_ext: ArrayLike | None = None,
-    ) -> "_LegacyStrapdownINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11:
+    ) -> (
+        "_LegacyStrapdownINS"
+    ):  # TODO: Replace with ``typing.Self`` when Python > 3.11:
         """
         Update the INS states by integrating the 'strapdown navigation equations'.
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -277,7 +277,7 @@ class StrapdownINS:
         w_ins = np.asarray_chkfinite(w_ins, dtype=float).reshape(3, 1)
 
         R_bn = _rot_matrix_from_quaternion(self.quaternion())  # body-to-ned
-        T = _angular_matrix_from_euler(self.quaternion())
+        T = _angular_matrix_from_quaternion(self.quaternion())
 
         if degrees:
             w_ins = (np.pi / 180.0) * w_ins

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -245,17 +245,17 @@ class StrapdownINS:
 
         The states are updated according to:
 
-            ``p[k+1] = p[k] + h * v[k] + 0.5 * dt * a[k]``
+            p[k+1] = p[k] + h * v[k] + 0.5 * dt * a[k]
 
-            ``v[k+1] = v[k] + dt * a[k]``
+            v[k+1] = v[k] + dt * a[k]
 
-            ``q[k+1] = q[k] + dt * T(q[k]) * w_ins[k]``
+            q[k+1] = q[k] + dt * T(q[k]) * w_ins[k]
 
         where,
 
-            ``a[k] = R(q[k]) * f_ins[k] + g``
+            a[k] = R(q[k]) * f_ins[k] + g
 
-            ``g = [0, 0, 9.81]^T``
+            g = [0, 0, 9.81]^T
 
         Parameters
         ----------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -79,8 +79,9 @@ class StrapdownINS:
         Initial state vector, containing the following elements in order:
             - Position in x-, y-, and z-direction (3 elements).
             - Velocity in x-, y-, and z-direction (3 elements).
-            - Attitude as unit quaternion (4 elements). Should be given as [q1, q2, q3, q4],
-              where q1 is the real part and q1, q2 and q3 are the three imaginary parts.
+            - Attitude as unit quaternion (4 elements). Should be given as
+              [q1, q2, q3, q4], where q1 is the real part and q1, q2 and q3 are
+              the three imaginary parts.
     lat : float, optional
         Latitude used to calculate the gravitational acceleration. If `lat` is ``None``,
         the 'standard gravity' (i.e., 9.80665) is used.
@@ -114,6 +115,23 @@ class StrapdownINS:
     @_q.setter
     def _q(self, q: ArrayLike) -> None:
         self._x[6:10] = q
+
+    @property
+    def x(self) -> NDArray[np.float64]:
+        """
+        Current state vector estimate.
+
+        Returns
+        -------
+        x : numpy.ndarray (10,)
+            State vector, containing the following elements in order:
+                - Position in x-, y-, and z-direction (3 elements).
+                - Velocity in x-, y-, and z-direction (3 elements).
+                - Attitude as unit quaternion (4 elements). Should be given as
+                  [q1, q2, q3, q4], where q1 is the real part and q1, q2 and q3
+                  are the three imaginary parts.
+        """
+        return self._x.flatten()
 
 
 class _LegacyStrapdownINS:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -67,6 +67,10 @@ def gravity(lat: float | None = None, degrees: bool = True) -> float:
 
 
 class StrapdownINS:
+    pass
+
+
+class _LegacyStrapdownINS:
     """
     Inertial navigation system (INS) strapdown algorithm.
 
@@ -399,7 +403,7 @@ class AidedINS:
 
         # Strapdown algorithm
         self._x_ins = self._x0
-        self._ins = StrapdownINS(self._x_ins[0:9])
+        self._ins = _LegacyStrapdownINS(self._x_ins[0:9])
 
         # Initial Kalman filter error covariance
         self._P_prior = np.eye(15)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -4,16 +4,16 @@ import numpy as np
 from numpy.linalg import inv
 from numpy.typing import ArrayLike, NDArray
 
-from ._vectorops import _normalize
 from ._ahrs import AHRS
 from ._transforms import (
     _angular_matrix_from_euler,
+    _angular_matrix_from_quaternion,
+    _euler_from_quaternion,
     _quaternion_from_euler,
     _rot_matrix_from_euler,
-    _euler_from_quaternion,
     _rot_matrix_from_quaternion,
-    _angular_matrix_from_quaternion,
 )
+from ._vectorops import _normalize
 
 
 def _signed_smallest_angle(angle: float, degrees: bool = True) -> float:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -110,7 +110,7 @@ class StrapdownINS:
 
     @property
     def _q(self) -> NDArray[np.float64]:
-        return self._x[6:9]
+        return self._x[6:10]
 
     @_q.setter
     def _q(self, q: ArrayLike) -> None:
@@ -156,6 +156,18 @@ class StrapdownINS:
             (in that order).
         """
         return self._v.flatten()
+
+    def quaternion(self) -> NDArray[np.float64]:
+        """
+        Current attitude estimate as unit quaternion (from-body-to-NED).
+
+        Returns
+        -------
+        q : numpy.ndarray (4,)
+            Attitude as unit quaternion. Given as [q1, q2, q3, q4], where q1 is
+            the real part and q1, q2 and q3 are the three imaginary parts.
+        """
+        return self._q.flatten()
 
 
 class _LegacyStrapdownINS:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -91,6 +91,30 @@ class StrapdownINS:
         self._x = self._x0.copy()
         self._g = np.array([0, 0, gravity(lat)]).reshape(3, 1)  # gravity vector in NED
 
+    @property
+    def _p(self) -> NDArray[np.float64]:
+        return self._x[0:3]
+
+    @_p.setter
+    def _p(self, p: ArrayLike) -> None:
+        self._x[0:3] = p
+
+    @property
+    def _v(self) -> NDArray[np.float64]:
+        return self._x[3:6]
+
+    @_v.setter
+    def _v(self, v: ArrayLike) -> None:
+        self._x[3:6] = v
+
+    @property
+    def _q(self) -> NDArray[np.float64]:
+        return self._x[6:9]
+
+    @_q.setter
+    def _q(self, q: ArrayLike) -> None:
+        self._x[6:10] = q
+
 
 class _LegacyStrapdownINS:
     """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -9,6 +9,7 @@ from ._transforms import (
     _angular_matrix_from_euler,
     _quaternion_from_euler,
     _rot_matrix_from_euler,
+    _euler_from_quaternion
 )
 
 
@@ -168,6 +169,47 @@ class StrapdownINS:
             the real part and q1, q2 and q3 are the three imaginary parts.
         """
         return self._q.flatten()
+
+    def euler(self, degrees: bool = False) -> NDArray[np.float64]:
+        """
+        Current attitude estimate as Euler angles (see Notes).
+
+        Parameters
+        ----------
+        degrees : bool
+            Whether to return the Euler angles in degrees (`True`) or radians (`False`).
+
+        Returns
+        -------
+        euler : numpy.ndarray
+            Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
+            in that order.
+
+        Notes
+        -----
+        The Euler angles describe how to transition from the 'NED' frame to the 'body'
+        frame through three consecutive intrinsic and passive rotations in the ZYX order:
+            1. A rotation by an angle gamma (often called yaw) about the z-axis.
+            2. A subsequent rotation by an angle beta (often called pitch) about the y-axis.
+            3. A final rotation by an angle alpha (often called roll) about the x-axis.
+
+        This sequence of rotations is used to describe the orientation of the 'body' frame
+        relative to the 'NED' frame in 3D space.
+
+        Intrinsic rotations mean that the rotations are with respect to the changing
+        coordinate system; as one rotation is applied, the next is about the axis of
+        the newly rotated system.
+
+        Passive rotations mean that the frame itself is rotating, not the object
+        within the frame.
+        """
+        q = self.quaternion()
+        theta = _euler_from_quaternion(q)
+
+        if degrees:
+            theta = (180.0 / np.pi) * theta
+
+        return theta
 
 
 class _LegacyStrapdownINS:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -67,7 +67,35 @@ def gravity(lat: float | None = None, degrees: bool = True) -> float:
 
 
 class StrapdownINS:
-    pass
+    """
+    Inertial navigation system (INS) strapdown algorithm.
+
+    This class provides an interface for estimating position, velocity and attitude
+    of a moving body by integrating the 'strapdown navigation equations'.
+
+    Parameters
+    ----------
+    x0 : array_like
+        Initial state vector as 1D array of length 10 (see Notes).
+    lat : float, optional
+        Latitude used to calculate the gravitational acceleration. If `lat` is ``None``,
+        the 'standard gravity' (i.e., 9.80665) is used.
+
+    Notes
+    -----
+    The state vector should be given as:
+
+        ``x = [p_x, p_y, p_z, v_x, v_y, v_z, alpha, beta, gamma]^T``
+
+    where ``p_x``, ``p_y`` and ``p_z`` are position coordinates (in x-, y- and z-direction),
+    ``v_x``, ``v_y`` and ``v_z`` are (linear) velocities (in x-, y- and z-direction),
+    and ``alpha``, ``beta`` and ``gamma`` are Euler angles (given in radians).
+    """
+
+    def __init__(self, x0: ArrayLike, lat: float | None = None) -> None:
+        self._x0 = np.asarray_chkfinite(x0).reshape(10, 1).copy()
+        self._x = self._x0.copy()
+        self._g = np.array([0, 0, gravity(lat)]).reshape(3, 1)  # gravity vector in NED
 
 
 class _LegacyStrapdownINS:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -261,14 +261,10 @@ class StrapdownINS:
         ----------
         dt : float
             Sampling period in seconds.
-        f_imu : array_like
-            IMU specific force measurements (i.e., accelerations + gravity). Given as
-            ``[f_x, f_y, f_z]^T`` where ``f_x``, ``f_y`` and ``f_z`` are
-            acceleration measurements in x-, y-, and z-direction, respectively.
-        w_imu : array_like
-            IMU rotation rate measurements. Given as ``[w_x, w_y, w_z]^T`` where
-            ``w_x``, ``w_y`` and ``w_z`` are rotation rates about the x-, y-,
-            and z-axis, respectively. Unit determined with ``degrees`` keyword argument.
+        f_ins : numpy.ndarray (3,)
+            Acceleration / specific force measurements (bias compensated).
+        w_imu : numpy.ndarray (3,)
+            Rotation rate measurements (bias compensated).
         degrees : bool, default False
             Whether the rotation rates are given in `degrees` (``True``) or `radians`
             (``False``).
@@ -479,7 +475,7 @@ class _LegacyStrapdownINS:
         w_imu: ArrayLike,
         degrees: bool = False,
         theta_ext: ArrayLike | None = None,
-    ) -> "StrapdownINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11:
+    ) -> "_LegacyStrapdownINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11:
         """
         Update the INS states by integrating the 'strapdown navigation equations'.
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -133,6 +133,18 @@ class StrapdownINS:
         """
         return self._x.flatten()
 
+    def position(self) -> NDArray[np.float64]:
+        """
+        Current position vector estimate.
+
+        Returns
+        -------
+        p : numpy.ndarray (3,)
+            Position state vector, containing position in x-, y-, and z-direction
+            (in that order).
+        """
+        return self._p.flatten()
+
 
 class _LegacyStrapdownINS:
     """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -181,7 +181,7 @@ class StrapdownINS:
 
         Returns
         -------
-        euler : numpy.ndarray
+        euler : numpy.ndarray (3,)
             Euler angles, specifically: alpha (roll), beta (pitch) and gamma (yaw)
             in that order.
 
@@ -210,6 +210,22 @@ class StrapdownINS:
             theta = (180.0 / np.pi) * theta
 
         return theta
+
+    def reset(self, x_new: ArrayLike) -> None:
+        """
+        Reset state.
+
+        Parameters
+        ----------
+        x_new : ndarray (10,)
+            New state vector, containing the following elements in order:
+                - Position in x-, y-, and z-direction (3 elements).
+                - Velocity in x-, y-, and z-direction (3 elements).
+                - Attitude as unit quaternion (4 elements). Should be given as
+                  [q1, q2, q3, q4], where q1 is the real part and q1, q2 and q3
+                  are the three imaginary parts.
+        """
+        self._x = np.asarray_chkfinite(x_new).reshape(10, 1).copy()
 
 
 class _LegacyStrapdownINS:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -145,6 +145,18 @@ class StrapdownINS:
         """
         return self._p.flatten()
 
+    def velocity(self) -> NDArray[np.float64]:
+        """
+        Current velocity vector estimate.
+
+        Returns
+        -------
+        v : numpy.ndarray (3,)
+            Velocity state vector, containing (linear) velocity in x-, y-, and z-direction
+            (in that order).
+        """
+        return self._v.flatten()
+
 
 class _LegacyStrapdownINS:
     """

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -64,6 +64,23 @@ def ains_ref_data():
 
 
 @pytest.mark.filterwarnings("ignore")
+class Test_StrapdownINS:
+    @pytest.fixture
+    def ins(self):
+        x0 = np.zeros((10, 1))
+        x0[6:10] = np.array([1.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+        return ins
+
+    def test__init__(self):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        np.testing.assert_array_equal(ins._x0, x0.reshape(-1, 1))
+        np.testing.assert_array_equal(ins._x, x0.reshape(-1, 1))
+
+
+@pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:
     @pytest.fixture
     def ins(self):

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -15,7 +15,7 @@ import pytest
 from pandas import read_parquet
 from scipy.spatial.transform import Rotation
 
-from smsfusion._ins import AHRS, AidedINS, StrapdownINS, _signed_smallest_angle, gravity
+from smsfusion._ins import AHRS, AidedINS, StrapdownINS, _signed_smallest_angle, gravity, _LegacyStrapdownINS
 from smsfusion._transforms import (
     _angular_matrix_from_euler,
     _quaternion_from_euler,
@@ -64,16 +64,16 @@ def ains_ref_data():
 
 
 @pytest.mark.filterwarnings("ignore")
-class Test_StrapdownINS:
+class Test_LegacyStrapdownINS:
     @pytest.fixture
     def ins(self):
         x0 = np.zeros((9, 1))
-        ins = StrapdownINS(x0)
+        ins = _LegacyStrapdownINS(x0)
         return ins
 
     def test__init__(self):
         x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.pi, np.pi / 2.0, np.pi / 4.0])
-        ins = StrapdownINS(x0)
+        ins = _LegacyStrapdownINS(x0)
 
         np.testing.assert_array_equal(ins._x0, x0.reshape(-1, 1))
         np.testing.assert_array_equal(ins._x, x0.reshape(-1, 1))
@@ -154,7 +154,7 @@ class Test_StrapdownINS:
 
     def test_update_return_self(self):
         x0 = np.zeros((9, 1))
-        strapdownins = StrapdownINS(x0)
+        strapdownins = _LegacyStrapdownINS(x0)
 
         dt = 0.1
         g = 9.80665
@@ -166,7 +166,7 @@ class Test_StrapdownINS:
 
     def test_update(self):
         x0 = np.zeros((9, 1))
-        ins = StrapdownINS(x0)
+        ins = _LegacyStrapdownINS(x0)
 
         h = 0.1
         g = ins._g
@@ -185,7 +185,7 @@ class Test_StrapdownINS:
 
     def test_update_deg(self):
         x0 = np.zeros((9, 1))
-        ins = StrapdownINS(x0)
+        ins = _LegacyStrapdownINS(x0)
 
         dt = 0.1
         g = ins._g
@@ -216,7 +216,7 @@ class Test_StrapdownINS:
 
     def test_update_twise(self):
         x0 = np.zeros((9, 1))
-        ins = StrapdownINS(x0)
+        ins = _LegacyStrapdownINS(x0)
 
         dt = 0.1
         g = ins._g
@@ -258,7 +258,7 @@ class Test_StrapdownINS:
         np.testing.assert_array_almost_equal(x2_out, x2_expect.flatten())
 
     def test_update_R_T(self):
-        ins = StrapdownINS(np.zeros((9, 1)))
+        ins = _LegacyStrapdownINS(np.zeros((9, 1)))
 
         h = 0.1
         g = ins._g
@@ -315,7 +315,7 @@ class Test_AidedINS:
         assert ains.ahrs._Kp == 0.050
         assert ains.ahrs._Ki == 0.035
         assert isinstance(ains.ahrs, AHRS)
-        assert isinstance(ains._ins, StrapdownINS)
+        assert isinstance(ains._ins, _LegacyStrapdownINS)
         np.testing.assert_array_almost_equal(ains._x_ins, np.zeros((15, 1)))
         np.testing.assert_array_almost_equal(ains._P_prior, np.eye(15))
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -147,6 +147,25 @@ class Test_StrapdownINS:
 
         np.testing.assert_array_equal(ins.x, x.flatten())
 
+    def test_update(self):
+        x0 = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        h = 0.1
+        g = ins._g
+        f = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
+        w = np.array([0.04, 0.05, 0.06]).reshape(-1, 1)
+
+        x0_out = ins.x
+        ins.update(h, f, w)
+        x1_out = ins.x
+
+        x0_expect = x0
+        x1_expect = np.array([0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.99999, 0.002, 0.0025, 0.003])
+
+        np.testing.assert_array_almost_equal(x0_out, x0_expect)
+        np.testing.assert_array_almost_equal(x1_out, x1_expect)
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -133,6 +133,20 @@ class Test_StrapdownINS:
         assert theta_out.shape == (3,)
         np.testing.assert_array_equal(theta_out, theta_expect)
 
+    def test_reset(self, ins):
+        x = np.random.random(10)
+        x[6:10] = x[6:10] / np.linalg.norm(x[6:10])  # unit quaternion
+        ins.reset(x)
+
+        np.testing.assert_array_equal(ins.x, x)
+
+    def test_reset_2d(self, ins):
+        x = np.random.random(10).reshape(-1, 1)
+        x[6:10] = x[6:10] / np.linalg.norm(x[6:10])  # unit quaternion
+        ins.reset(x)
+
+        np.testing.assert_array_equal(ins.x, x.flatten())
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -112,6 +112,17 @@ class Test_StrapdownINS:
         assert v_out is not ins._v
         np.testing.assert_array_equal(v_out, v_expect)
 
+    def test_quaternion(self, ins):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        q_out = ins.quaternion()
+        q_expect = np.array([1.0, 0.0, 0.0, 0.0])
+
+        assert q_out.shape == (4,)
+        assert q_out is not ins._q
+        np.testing.assert_array_equal(q_out, q_expect)
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -180,6 +180,25 @@ class Test_StrapdownINS:
         np.testing.assert_array_almost_equal(x0_out, x0_expect)
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
 
+    def test_update_deg(self, ins):
+
+        dt = 0.1
+        g = ins._g
+        f_imu = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
+        w_imu = np.array([4.0, 5.0, 6.0]).reshape(-1, 1)
+
+        x0_out = ins.x
+        ins.update(dt, f_imu, w_imu, degrees=True)
+        x1_out = ins.x
+
+        x0_expect = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        x1_expect = np.array(
+            [0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.999971, 0.003491, 0.004363, 0.005236]
+        )
+
+        np.testing.assert_array_almost_equal(x0_out, x0_expect)
+        np.testing.assert_array_almost_equal(x1_out, x1_expect)
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -25,9 +25,9 @@ from smsfusion._ins import (
 )
 from smsfusion._transforms import (
     _angular_matrix_from_euler,
+    _angular_matrix_from_quaternion,
     _quaternion_from_euler,
     _rot_matrix_from_euler,
-    _angular_matrix_from_quaternion,
     _rot_matrix_from_quaternion,
 )
 
@@ -212,7 +212,9 @@ class Test_StrapdownINS:
         ins.update(dt, f_imu, w_imu, degrees=False)
         x2_out = ins.x
 
-        x0_expect = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).reshape(-1, 1)
+        x0_expect = np.array(
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+        ).reshape(-1, 1)
 
         # Calculate x1
         R0_expect = np.eye(3)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -67,8 +67,8 @@ def ains_ref_data():
 class Test_StrapdownINS:
     @pytest.fixture
     def ins(self):
-        x0 = np.zeros((10, 1))
-        x0[6:10] = np.array([1.0, 0.0, 0.0])
+        x0 = np.zeros(10)
+        x0[6:10] = np.array([1.0, 0.0, 0.0, 0.0])
         ins = StrapdownINS(x0)
         return ins
 
@@ -78,6 +78,17 @@ class Test_StrapdownINS:
 
         np.testing.assert_array_equal(ins._x0, x0.reshape(-1, 1))
         np.testing.assert_array_equal(ins._x, x0.reshape(-1, 1))
+
+    def test_x(self):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        x_out = ins.x
+        x_expect = x0
+
+        assert x_out.shape == (10,)
+        assert x_out is not ins._x
+        np.testing.assert_array_equal(x_out, x_expect)
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -90,6 +90,17 @@ class Test_StrapdownINS:
         assert x_out is not ins._x
         np.testing.assert_array_equal(x_out, x_expect)
 
+    def test_position(self, ins):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        p_out = ins.position()
+        p_expect = np.array([1.0, 2.0, 3.0])
+
+        assert p_out.shape == (3,)
+        assert p_out is not ins._p
+        np.testing.assert_array_equal(p_out, p_expect)
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -90,7 +90,7 @@ class Test_StrapdownINS:
         assert x_out is not ins._x
         np.testing.assert_array_equal(x_out, x_expect)
 
-    def test_position(self, ins):
+    def test_position(self):
         x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
         ins = StrapdownINS(x0)
 
@@ -101,7 +101,7 @@ class Test_StrapdownINS:
         assert p_out is not ins._p
         np.testing.assert_array_equal(p_out, p_expect)
 
-    def test_velocity(self, ins):
+    def test_velocity(self):
         x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
         ins = StrapdownINS(x0)
 
@@ -112,7 +112,7 @@ class Test_StrapdownINS:
         assert v_out is not ins._v
         np.testing.assert_array_equal(v_out, v_expect)
 
-    def test_quaternion(self, ins):
+    def test_quaternion(self):
         x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
         ins = StrapdownINS(x0)
 
@@ -122,6 +122,16 @@ class Test_StrapdownINS:
         assert q_out.shape == (4,)
         assert q_out is not ins._q
         np.testing.assert_array_equal(q_out, q_expect)
+
+    def test_euler(self):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        theta_out = ins.euler()
+        theta_expect = np.array([0.0, 0.0, 0.0])
+
+        assert theta_out.shape == (3,)
+        np.testing.assert_array_equal(theta_out, theta_expect)
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -204,12 +204,12 @@ class Test_StrapdownINS:
         dt = 0.1
         g = ins._g
         f_imu = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
-        w_imu = np.array([4.0, 5.0, 6.0]).reshape(-1, 1)
+        w_imu = np.array([0.004, 0.005, 0.006]).reshape(-1, 1)
 
         x0_out = ins.x
-        ins.update(dt, f_imu, w_imu, degrees=True)
+        ins.update(dt, f_imu, w_imu, degrees=False)
         x1_out = ins.x
-        ins.update(dt, f_imu, w_imu, degrees=True)
+        ins.update(dt, f_imu, w_imu, degrees=False)
         x2_out = ins.x
 
         x0_expect = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).reshape(-1, 1)
@@ -223,7 +223,7 @@ class Test_StrapdownINS:
             x0_expect[0:3] + dt * x0_expect[3:6] + 0.5 * dt**2 * a0_expect
         )
         x1_expect[3:6] = x0_expect[3:6] + dt * a0_expect
-        x1_expect[6:10] = x0_expect[6:10] + (np.pi / 180.0) * dt * T0_expect @ w_imu
+        x1_expect[6:10] = x0_expect[6:10] + dt * T0_expect @ w_imu
         x1_expect[6:10] = x1_expect[6:10] / np.linalg.norm(x1_expect[6:10])
 
         # Calculate x2 by forward Euler
@@ -235,7 +235,7 @@ class Test_StrapdownINS:
             x1_expect[0:3] + dt * x1_expect[3:6] + 0.5 * dt**2 * a1_expect
         )
         x2_expect[3:6] = x1_expect[3:6] + dt * a1_expect
-        x2_expect[6:10] = x1_expect[6:10] + (np.pi / 180.0) * dt * T1_expect @ w_imu
+        x2_expect[6:10] = x1_expect[6:10] + dt * T1_expect @ w_imu
         x2_expect[6:10] = x2_expect[6:10] / np.linalg.norm(x2_expect[6:10])
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect.flatten())

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -101,6 +101,17 @@ class Test_StrapdownINS:
         assert p_out is not ins._p
         np.testing.assert_array_equal(p_out, p_expect)
 
+    def test_velocity(self, ins):
+        x0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0])
+        ins = StrapdownINS(x0)
+
+        v_out = ins.velocity()
+        v_expect = np.array([4.0, 5.0, 6.0])
+
+        assert v_out.shape == (3,)
+        assert v_out is not ins._v
+        np.testing.assert_array_equal(v_out, v_expect)
+
 
 @pytest.mark.filterwarnings("ignore")
 class Test_LegacyStrapdownINS:

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -181,7 +181,6 @@ class Test_StrapdownINS:
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
 
     def test_update_deg(self, ins):
-
         dt = 0.1
         g = ins._g
         f_imu = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g


### PR DESCRIPTION
### This PR is related to user story DLAB-66

## Description
Duplicated StrapdownINS (renamed the old one to `_LegacyStrapdownINS`). The new strapdown algorithm uses quaternions as the internal attitude representation.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
