### PR TITLE
Add private function for quaternion (Schur) product

### DIFF
--- a/src/smsfusion/_vectorops.py
+++ b/src/smsfusion/_vectorops.py
@@ -39,5 +39,5 @@ def _quaternion_product(
             qa_w * qb_w - qa_xyz.T @ qb_xyz,
             qa_w * qb_xyz + qb_w * qa_xyz + np.cross(qa_xyz, qb_xyz),
         ),
-        axis=0
+        axis=0,
     )

--- a/src/smsfusion/_vectorops.py
+++ b/src/smsfusion/_vectorops.py
@@ -23,3 +23,21 @@ def _cross(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64
             a[0] * b[1] - a[1] * b[0],
         ]
     )
+
+
+@njit  # type: ignore[misc]
+def _quaternion_product(
+    qa: NDArray[np.float64], qb: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """
+    Unit quaternion (Schur) product.
+    """
+    qa_w, qa_xyz = np.split(qa, [1])
+    qb_w, qb_xyz = np.split(qb, [1])
+    return np.concatenate(
+        (
+            qa_w * qb_w - qa_xyz.T @ qb_xyz,
+            qa_w * qb_xyz + qb_w * qa_xyz + np.cross(qa_xyz, qb_xyz),
+        ),
+        axis=0
+    )

--- a/tests/test_vectorops.py
+++ b/tests/test_vectorops.py
@@ -38,7 +38,7 @@ def test__cross():
 
 
 @pytest.mark.parametrize(
-    "euler_a, euler_b", np.random.uniform(0., 360., size=(10, 2, 3)).tolist()
+    "euler_a, euler_b", np.random.uniform(0.0, 360.0, size=(10, 2, 3)).tolist()
 )
 def test___quaternion_product(euler_a, euler_b):
     rot_a = Rotation.from_euler("ZYX", euler_a, degrees=True).inv()
@@ -57,4 +57,3 @@ def test___quaternion_product(euler_a, euler_b):
 
     q_ab_out = _vectorops._quaternion_product(q_a, q_b)
     np.testing.assert_array_almost_equal(q_ab, q_ab_out)
-

--- a/tests/test_vectorops.py
+++ b/tests/test_vectorops.py
@@ -1,4 +1,16 @@
+"""
+IMPORTANT
+---------
+
+SciPy Rotation implementation is used as reference in tests. However, SciPy
+operates with active rotations, whereas passive rotations are considered here. Keep in
+mind that passive rotations is simply the inverse active rotations and vice versa.
+"""
+
+
 import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
 
 from smsfusion import _vectorops
 
@@ -23,3 +35,26 @@ def test__cross():
 
     expected = np.cross(a, b)
     np.testing.assert_array_equal(out, expected)
+
+
+@pytest.mark.parametrize(
+    "euler_a, euler_b", np.random.uniform(0., 360., size=(10, 2, 3)).tolist()
+)
+def test___quaternion_product(euler_a, euler_b):
+    rot_a = Rotation.from_euler("ZYX", euler_a, degrees=True).inv()
+    rot_b = Rotation.from_euler("ZYX", euler_b, degrees=True).inv()
+
+    rot_ab = rot_a * rot_b
+
+    q_a = rot_a.as_quat()
+    q_a = np.r_[q_a[3], q_a[:3]]
+
+    q_b = rot_b.as_quat()
+    q_b = np.r_[q_b[3], q_b[:3]]
+
+    q_ab = rot_ab.as_quat()
+    q_ab = np.r_[q_ab[3], q_ab[:3]]
+
+    q_ab_out = _vectorops._quaternion_product(q_a, q_b)
+    np.testing.assert_array_almost_equal(q_ab, q_ab_out)
+


### PR DESCRIPTION
### This PR is related to user story DLAB-67

## Description
Add function for quaternion product.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
