### PR TITLE
Enforce normalization of quaternions given to StrapdownINS.

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -89,11 +89,17 @@ class StrapdownINS:
     lat : float, optional
         Latitude used to calculate the gravitational acceleration. If `lat` is ``None``,
         the 'standard gravity' (i.e., 9.80665) is used.
+
+    Notes
+    -----
+    The quaternion provided as part of the initial state will be normalized to
+    ensure unity.
     """
 
     def __init__(self, x0: ArrayLike, lat: float | None = None) -> None:
         self._x0 = np.asarray_chkfinite(x0).reshape(10, 1).copy()
         self._x = self._x0.copy()
+        self._x[6:] = _normalize(self._x[6:])
         self._g = np.array([0, 0, gravity(lat)]).reshape(3, 1)  # gravity vector in NED
 
     @property
@@ -227,8 +233,14 @@ class StrapdownINS:
                 - Attitude as unit quaternion (4 elements). Should be given as
                   [q1, q2, q3, q4], where q1 is the real part and q1, q2 and q3
                   are the three imaginary parts.
+
+        Notes
+        -----
+        The quaternion provided as part of the new state will be normalized to
+        ensure unity.
         """
         self._x = np.asarray_chkfinite(x_new).reshape(10, 1).copy()
+        self._x[6:] = _normalize(self._x[6:])
 
     def update(
         self,

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -151,14 +151,14 @@ class Test_StrapdownINS:
         x[6:10] = x[6:10] / np.linalg.norm(x[6:10])  # unit quaternion
         ins.reset(x)
 
-        np.testing.assert_array_equal(ins.x, x)
+        np.testing.assert_array_almost_equal(ins.x, x)
 
     def test_reset_2d(self, ins):
         x = np.random.random(10).reshape(-1, 1)
         x[6:10] = x[6:10] / np.linalg.norm(x[6:10])  # unit quaternion
         ins.reset(x)
 
-        np.testing.assert_array_equal(ins.x, x.flatten())
+        np.testing.assert_array_almost_equal(ins.x, x.flatten())
 
     def test_update_return_self(self, ins):
         dt = 0.1


### PR DESCRIPTION
### This PR is related to user story DLAB-71

## Description
The StrapdownINS can be given quaterions at init or reset. Added normalization to enforce unity.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
