### PR TITLE
Include biases in StrapdownINS state

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -85,6 +85,7 @@ class BaseINS(ABC):
 
     def __init__(self, x0):
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
+        self._x0[6:] = _normalize(self._x0[6:])
         self._x = self._x0.copy()
 
     @property

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC
 
 import numpy as np
 from numpy.linalg import inv

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -85,7 +85,7 @@ class BaseINS(ABC):
 
     def __init__(self, x0):
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
-        self._x0[6:] = _normalize(self._x0[6:])
+        self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()
 
     @property
@@ -125,7 +125,7 @@ class BaseINS(ABC):
         return self._x[13:16]
 
     @_b_gyro.setter
-    def _p(self, b_gyro: ArrayLike) -> None:
+    def _b_gyro(self, b_gyro: ArrayLike) -> None:
         self._x[13:16] = b_gyro
 
     @property
@@ -286,7 +286,7 @@ class StrapdownINS(BaseINS):
     """
 
     def __init__(self, x0: ArrayLike, lat: float | None = None) -> None:
-        self._g = np.array([0, 0, gravity(lat)]).reshape(3, 1)  # gravity vector in NED
+        self._g = np.array([0, 0, gravity(lat)])  # gravity vector in NED
         super().__init__(x0)
 
     def reset(self, x_new: ArrayLike) -> None:
@@ -309,8 +309,8 @@ class StrapdownINS(BaseINS):
         The quaternion provided as part of the new state will be normalized to
         ensure unity.
         """
-        self._x = np.asarray_chkfinite(x_new).reshape(10, 1).copy()
-        self._x[6:] = _normalize(self._x[6:])
+        self._x = np.asarray_chkfinite(x_new).reshape(16).copy()
+        self._x[6:10] = _normalize(self._x[6:10])
 
     def update(
         self,
@@ -366,8 +366,8 @@ class StrapdownINS(BaseINS):
             w_imu = (np.pi / 180.0) * w_imu
 
         # Bias compensated IMU measurements
-        f_ins = f_imu - self._b_acc
-        w_ins = w_imu - self._b_gyro
+        f_ins = f_imu - self.bias_acc()
+        w_ins = w_imu - self.bias_gyro()
 
         R_bn = _rot_matrix_from_quaternion(self._q)  # body-to-ned
         T = _angular_matrix_from_quaternion(self._q)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -804,8 +804,6 @@ class AidedINS(BaseINS):
         if head is not None:
             if head_degrees:
                 head = (np.pi / 180.0) * head
-
-            # head = np.asarray_chkfinite([head], dtype=float).reshape(1).copy()
             delta_head = _signed_smallest_angle(head - _h(_gibbs(q_ins)), degrees=False)
             dz_temp.append(np.array([delta_head]))
             var_z_temp.append(self._var_compass)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -106,21 +106,41 @@ class BaseINS(ABC):
     def _p(self) -> NDArray[np.float64]:
         return self._x[0:3]
 
+    @_p.setter
+    def _p(self, p: ArrayLike) -> None:
+        self._x[0:3] = p
+
     @property
     def _v(self) -> NDArray[np.float64]:
         return self._x[3:6]
+
+    @_v.setter
+    def _v(self, v: ArrayLike) -> None:
+        self._x[3:6] = v
 
     @property
     def _q(self) -> NDArray[np.float64]:
         return self._x[6:10]
 
+    @_q.setter
+    def _q(self, q: ArrayLike) -> None:
+        self._x[6:10] = q
+
     @property
     def _b_acc(self) -> NDArray[np.float64]:
         return self._x[10:13]
 
+    @_b_acc.setter
+    def _b_acc(self, b_acc: ArrayLike) -> None:
+        self._x[10:13] = b_acc
+
     @property
     def _b_gyro(self) -> NDArray[np.float64]:
         return self._x[13:16]
+
+    @_b_gyro.setter
+    def _p(self, b_gyro: ArrayLike) -> None:
+        self._x[13:16] = b_gyro
 
     @property
     def x(self) -> NDArray[np.float64]:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -80,7 +80,7 @@ def gravity(lat: float | None = None, degrees: bool = True) -> float:
 
 class BaseINS(ABC):
     """
-    Abstract class for inertial navigation systems (INSs).
+    Abstract class for inertial navigation systems (INS).
 
     Parameters
     ----------
@@ -92,6 +92,11 @@ class BaseINS(ABC):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
+
+    Notes
+    -----
+    The quaternion provided as part of the initial state will be normalized to
+    ensure unity.
     """
 
     def __init__(self, x0: ArrayLike) -> None:
@@ -373,7 +378,7 @@ class StrapdownINS(BaseINS):
 
         Returns
         -------
-        AidedINS
+        StrapdownINS :
             A reference to the instance itself after the update.
         """
         f_imu = np.asarray_chkfinite(f_imu, dtype=float).reshape(3)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -366,8 +366,8 @@ class StrapdownINS(BaseINS):
             w_imu = (np.pi / 180.0) * w_imu
 
         # Bias compensated IMU measurements
-        f_ins = f_imu - self.bias_acc()
-        w_ins = w_imu - self.bias_gyro()
+        f_ins = f_imu - self._b_acc
+        w_ins = w_imu - self._b_gyro
 
         R_bn = _rot_matrix_from_quaternion(self._q)  # body-to-ned
         T = _angular_matrix_from_quaternion(self._q)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -94,7 +94,7 @@ class BaseINS(ABC):
         * Gyroscope bias in x, y, z directions (3 elements).
     """
 
-    def __init__(self, x0):
+    def __init__(self, x0: ArrayLike) -> None:
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -92,6 +92,8 @@ class INSMixin:
         * Gyroscope bias in x, y, z directions (3 elements).
     """
 
+    _x: ArrayLike  # state array of length 16
+
     @property
     def _p(self) -> NDArray[np.float64]:
         return self._x[0:3]

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -278,14 +278,14 @@ class StrapdownINS(BaseINS):
 
     Parameters
     ----------
-    x0 : numpy.ndarray, shape (10,)
-        Initial state vector, containing the following elements in order:
+    x0 : array-like, shape (16,)
+        Initial state vector containing the following elements in order:
 
-        * Position in x-, y-, and z-direction (3 elements).
-        * Velocity in x-, y-, and z-direction (3 elements).
-        * Attitude as unit quaternion (4 elements). Should be given as
-          [q1, q2, q3, q4], where q1 is the real part and q1, q2 and q3 are
-          the three imaginary parts.
+        * Position in x, y, z directions (3 elements).
+        * Velocity in x, y, z directions (3 elements).
+        * Attitude as unit quaternion (4 elements).
+        * Accelerometer bias in x, y, z directions (3 elements).
+        * Gyroscope bias in x, y, z directions (3 elements).
     lat : float, optional
         Latitude used to calculate the gravitational acceleration. If none
         provided, the 'standard gravity' is assumed.
@@ -344,11 +344,21 @@ class StrapdownINS(BaseINS):
 
             q[k+1] = q[k] + dt * T(q[k]) * w_ins[k]
 
-        where,::
+        with bias compensated IMU measurements,::
+
+            f_ins[k] = f_imu[k] - b_acc[k]
+
+            w_ins[k] = w_imu[k] - b_gyro[k]
+
+        and,::
 
             a[k] = R(q[k]) * f_ins[k] + g
 
             g = [0, 0, 9.81]^T
+
+            f_ins[k] = f_imu[k] - b_acc[k]
+
+            w_ins[k] = w_imu[k] - b_gyro[k]
 
         Parameters
         ----------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -83,24 +83,9 @@ class BaseINS(ABC):
     Abstract class for inertial navigation systems (INSs).
     """
 
-    @property
-    @abstractmethod
-    def _x(self) -> NDArray[np.float64]:
-        """
-        State vector, containing the following elements in order:
-
-            * Position in x, y, z directions (3 elements).
-            * Velocity in x, y, z directions (3 elements).
-            * Attitude as unit quaternion (4 elements).
-            * Accelerometer bias in x, y, z directions (3 elements).
-            * Gyroscope bias in x, y, z directions (3 elements).
-        """
-        raise NotImplementedError()
-
-    @_x.setter
-    @abstractmethod
-    def _x(self) -> NDArray[np.float64]:
-        raise NotImplementedError()
+    def __init__(self, x0):
+        self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
+        self._x = self._x0.copy()
 
     @property
     def _p(self) -> NDArray[np.float64]:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -343,14 +343,14 @@ class StrapdownINS(BaseINS):
         ----------
         dt : float
             Sampling period in seconds.
-        f_imu : array_like, shape (3,)
-            Specific force (bias compansated) measurements (i.e., accelerations
-            + gravity), given as [f_x, f_y, f_z]^T where f_x, f_y and f_z are
+        f_imu : array-like, shape (3,)
+            Specific force measurements (i.e., accelerations + gravity), given
+            as [f_x, f_y, f_z]^T where f_x, f_y and f_z are
             acceleration measurements in x-, y-, and z-direction, respectively.
-        w_imu : array_like, shape (3,)
-            Angular rate (bias compansated) measurements, given as
-            [w_x, w_y, w_z]^T where w_x, w_y and w_z are angular rates about
-            the x-, y-, and z-axis, respectively.
+        w_imu : array-like, shape (3,)
+            Angular rate measurements, given as [w_x, w_y, w_z]^T where
+            w_x, w_y and w_z are angular rates about the x-, y-,
+            and z-axis, respectively.
         degrees : bool, default False
             Specify whether the angular rates are given in degrees or radians.
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -83,15 +83,11 @@ class BaseINS(ABC):
     Abstract class for inertial navigation systems (INSs).
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _x(self) -> NDArray[np.float64]:
         """
-        Current state vector estimate.
-
-        Returns
-        -------
-        numpy.ndarray, shape (16,)
-            State vector, containing the following elements in order:
+        State vector, containing the following elements in order:
 
             * Position in x, y, z directions (3 elements).
             * Velocity in x, y, z directions (3 elements).
@@ -99,6 +95,11 @@ class BaseINS(ABC):
             * Accelerometer bias in x, y, z directions (3 elements).
             * Gyroscope bias in x, y, z directions (3 elements).
         """
+        raise NotImplementedError()
+
+    @_x.setter
+    @abstractmethod
+    def _x(self) -> NDArray[np.float64]:
         raise NotImplementedError()
 
     @property

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -81,6 +81,17 @@ def gravity(lat: float | None = None, degrees: bool = True) -> float:
 class BaseINS(ABC):
     """
     Abstract class for inertial navigation systems (INSs).
+
+    Parameters
+    ----------
+    x0 : array-like, shape (16,)
+        Initial state vector containing the following elements in order:
+
+        * Position in x, y, z directions (3 elements).
+        * Velocity in x, y, z directions (3 elements).
+        * Attitude as unit quaternion (4 elements).
+        * Accelerometer bias in x, y, z directions (3 elements).
+        * Gyroscope bias in x, y, z directions (3 elements).
     """
 
     def __init__(self, x0):

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -286,18 +286,8 @@ class StrapdownINS(BaseINS):
     """
 
     def __init__(self, x0: ArrayLike, lat: float | None = None) -> None:
-        self._x0 = np.asarray_chkfinite(x0).reshape(10, 1).copy()
-        self._x = self._x0.copy()
-        self._x[6:] = _normalize(self._x[6:])
         self._g = np.array([0, 0, gravity(lat)]).reshape(3, 1)  # gravity vector in NED
-
-    @property
-    def _x(self):
-        return self._state_vector
-
-    @_x.setter
-    def _x(self, x):
-        self._state_vector = x
+        super().__init__(x0)
 
     def reset(self, x_new: ArrayLike) -> None:
         """

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -690,7 +690,7 @@ class AidedINS(BaseINS):
         head: float | None = None,
         degrees: bool = False,
         head_degrees: bool = True,
-    ) -> "MEKF":  # TODO: Replace with ``typing.Self`` when Python > 3.11
+    ) -> "AidedINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11
         """
         Update the AINS state estimates based on measurements.
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -344,21 +344,17 @@ class StrapdownINS(BaseINS):
 
             q[k+1] = q[k] + dt * T(q[k]) * w_ins[k]
 
-        with bias compensated IMU measurements,::
+        with bias compensated IMU measurements::
 
             f_ins[k] = f_imu[k] - b_acc[k]
 
             w_ins[k] = w_imu[k] - b_gyro[k]
 
-        and,::
+        and::
 
             a[k] = R(q[k]) * f_ins[k] + g
 
             g = [0, 0, 9.81]^T
-
-            f_ins[k] = f_imu[k] - b_acc[k]
-
-            w_ins[k] = w_imu[k] - b_gyro[k]
 
         Parameters
         ----------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -519,7 +519,6 @@ class AidedINS(BaseINS):
         self._dt = 1.0 / fs
         self._err_acc = err_acc
         self._err_gyro = err_gyro
-        # self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._var_pos = np.asarray_chkfinite(var_pos).reshape(3).copy()
         self._var_vel = np.asarray_chkfinite(var_vel).reshape(3).copy()
         self._var_g = np.asarray_chkfinite(var_g).reshape(3).copy()
@@ -542,11 +541,6 @@ class AidedINS(BaseINS):
         self._dfdw = self._prep_dfdw_matrix(q0)
         self._dhdx = self._prep_dhdx_matrix(q0)
         self._W = self._prep_W_matrix(err_acc, err_gyro)
-
-    # @property
-    # def _x(self) -> NDArray[np.float64]:
-    #     """Full state (i.e., INS state + error state)"""
-    #     return self._ins._x  # error state is zero due to reset
 
     @property
     def P(self) -> NDArray[np.float64]:
@@ -726,8 +720,7 @@ class AidedINS(BaseINS):
         if degrees:
             w_imu = (np.pi / 180.0) * w_imu
 
-        # Update INS state
-        # self._x_ins[0:10] = self._ins.x
+        # Update current state estimate
         self._x = self._ins.x
 
         # Current state estimates

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -261,16 +261,52 @@ class Test_StrapdownINS:
     def test_update_deg(self, ins):
         dt = 0.1
         g = ins._g
-        f_imu = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
-        w_imu = np.array([4.0, 5.0, 6.0]).reshape(-1, 1)
+        f_imu = np.array([1.0, 2.0, 3.0]) - g
+        w_imu = np.array([4.0, 5.0, 6.0])
 
         x0_out = ins.x
         ins.update(dt, f_imu, w_imu, degrees=True)
         x1_out = ins.x
 
-        x0_expect = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        x0_expect = np.array(
+            [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        )
         x1_expect = np.array(
-            [0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.999971, 0.003491, 0.004363, 0.005236]
+            [
+                0.005,
+                0.01,
+                0.015,
+                0.1,
+                0.2,
+                0.3,
+                0.999971,
+                0.003491,
+                0.004363,
+                0.005236,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
         )
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -315,8 +315,8 @@ class Test_StrapdownINS:
     def test_update_twise(self, ins):
         dt = 0.1
         g = ins._g
-        f_imu = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
-        w_imu = np.array([0.004, 0.005, 0.006]).reshape(-1, 1)
+        f_imu = np.array([1.0, 2.0, 3.0]) - g
+        w_imu = np.array([0.004, 0.005, 0.006])
 
         x0_out = ins.x
         ins.update(dt, f_imu, w_imu, degrees=False)
@@ -325,14 +325,31 @@ class Test_StrapdownINS:
         x2_out = ins.x
 
         x0_expect = np.array(
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
-        ).reshape(-1, 1)
+            [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        )
 
         # Calculate x1
         R0_expect = np.eye(3)
-        T0_expect = _angular_matrix_from_quaternion(x0_expect[6:10].flatten())
+        T0_expect = _angular_matrix_from_quaternion(x0_expect[6:10])
         a0_expect = R0_expect @ f_imu + g
-        x1_expect = np.zeros((10, 1))
+        x1_expect = np.zeros(16)
         x1_expect[0:3] = (
             x0_expect[0:3] + dt * x0_expect[3:6] + 0.5 * dt**2 * a0_expect
         )
@@ -341,10 +358,10 @@ class Test_StrapdownINS:
         x1_expect[6:10] = x1_expect[6:10] / np.linalg.norm(x1_expect[6:10])
 
         # Calculate x2 by forward Euler
-        R1_expect = _rot_matrix_from_quaternion(x1_expect[6:10].flatten())
-        T1_expect = _angular_matrix_from_quaternion(x1_expect[6:10].flatten())
+        R1_expect = _rot_matrix_from_quaternion(x1_expect[6:10])
+        T1_expect = _angular_matrix_from_quaternion(x1_expect[6:10])
         a1_expect = R1_expect @ f_imu + g
-        x2_expect = np.zeros((10, 1))
+        x2_expect = np.zeros(16)
         x2_expect[0:3] = (
             x1_expect[0:3] + dt * x1_expect[3:6] + 0.5 * dt**2 * a1_expect
         )

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -181,6 +181,26 @@ class Test_StrapdownINS:
         assert theta_out.shape == (3,)
         np.testing.assert_array_equal(theta_out, theta_expect)
 
+    def test_bias_acc(self, x0_nonzero):
+        ins = StrapdownINS(x0_nonzero)
+
+        ba_out = ins.bias_acc()
+        ba_expect = np.array([7.0, 8.0, 9.0])
+
+        assert ba_out.shape == (3,)
+        assert ba_out is not ins._v
+        np.testing.assert_array_equal(ba_out, ba_expect)
+
+    def test_bias_gyro(self, x0_nonzero):
+        ins = StrapdownINS(x0_nonzero)
+
+        bg_out = ins.bias_gyro()
+        bg_expect = np.array([10.0, 11.0, 12.0])
+
+        assert bg_out.shape == (3,)
+        assert bg_out is not ins._v
+        np.testing.assert_array_equal(bg_out, bg_expect)
+
     def test_reset(self, ins):
         x = np.random.random(16)
         x[6:10] = x[6:10] / np.linalg.norm(x[6:10])  # unit quaternion

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -107,78 +107,58 @@ class Test_INSMixin:
         x = np.r_[p, v, q, ba, bg]
         return x
 
-    def test_x(self, x):
-        ins = INSMixin()
-        ins._x = x
+    @pytest.fixture
+    def ins(self, x):
+        class INS(INSMixin):
+            def __init__(self, x):
+                self._x = x
 
+        return INS(x)
+
+    def test_x(self, x, ins):
         x_out = ins.x
         x_expect = x
-
         assert x_out.shape == (16,)
         assert x_out is not ins._x
         np.testing.assert_array_equal(x_out, x_expect)
 
-    def test_position(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_position(self, x, ins):
         p_out = ins.position()
         p_expect = np.array([1.0, 2.0, 3.0])
-
         assert p_out.shape == (3,)
         assert p_out is not ins._p
         np.testing.assert_array_equal(p_out, p_expect)
 
-    def test_velocity(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_velocity(self, x, ins):
         v_out = ins.velocity()
         v_expect = np.array([4.0, 5.0, 6.0])
-
         assert v_out.shape == (3,)
         assert v_out is not ins._v
         np.testing.assert_array_equal(v_out, v_expect)
 
-    def test_quaternion(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_quaternion(self, x, ins):
         q_out = ins.quaternion()
         q_expect = np.array([1.0, 0.0, 0.0, 0.0])
-
         assert q_out.shape == (4,)
         assert q_out is not ins._q
         np.testing.assert_array_equal(q_out, q_expect)
 
-    def test_euler(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_euler(self, x, ins):
         theta_out = ins.euler()
         theta_expect = np.array([0.0, 0.0, 0.0])
-
         assert theta_out.shape == (3,)
         np.testing.assert_array_equal(theta_out, theta_expect)
 
-    def test_bias_acc(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_bias_acc(self, x, ins):
         ba_out = ins.bias_acc()
         ba_expect = np.array([7.0, 8.0, 9.0])
-
         assert ba_out.shape == (3,)
         assert ba_out is not ins._v
         np.testing.assert_array_equal(ba_out, ba_expect)
 
-    def test_bias_gyro(self, x):
-        ins = INSMixin()
-        ins._x = x
-
+    def test_bias_gyro(self, x, ins):
         bg_out = ins.bias_gyro()
         bg_expect = np.array([10.0, 11.0, 12.0])
-
         assert bg_out.shape == (3,)
         assert bg_out is not ins._v
         np.testing.assert_array_equal(bg_out, bg_expect)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -18,7 +18,7 @@ from scipy.spatial.transform import Rotation
 
 from smsfusion._ins import (
     AidedINS,
-    BaseINS,
+    INSMixin,
     StrapdownINS,
     _dhda,
     _gibbs,
@@ -96,36 +96,31 @@ def ains_ref_data():
 
 
 @pytest.mark.filterwarnings("ignore")
-class Test_BaseINS:
+class Test_INSMixin:
     @pytest.fixture
-    def x0_nonzero(self):
-        p0 = np.array([1.0, 2.0, 3.0])
-        v0 = np.array([4.0, 5.0, 6.0])
-        q0 = np.array([1.0, 0.0, 0.0, 0.0])
-        ba0 = np.array([7.0, 8.0, 9.0])
-        bg0 = np.array([10.0, 11.0, 12.0])
-        x0 = np.r_[p0, v0, q0, ba0, bg0]
-        return x0
+    def x(self):
+        p = np.array([1.0, 2.0, 3.0])
+        v = np.array([4.0, 5.0, 6.0])
+        q = np.array([1.0, 0.0, 0.0, 0.0])
+        ba = np.array([7.0, 8.0, 9.0])
+        bg = np.array([10.0, 11.0, 12.0])
+        x = np.r_[p, v, q, ba, bg]
+        return x
 
-    def test__init__(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
-
-        assert isinstance(ins, BaseINS)
-        np.testing.assert_array_equal(ins._x0, x0_nonzero)
-        np.testing.assert_array_equal(ins._x, x0_nonzero)
-
-    def test_x(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_x(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         x_out = ins.x
-        x_expect = x0_nonzero
+        x_expect = x
 
         assert x_out.shape == (16,)
         assert x_out is not ins._x
         np.testing.assert_array_equal(x_out, x_expect)
 
-    def test_position(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_position(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         p_out = ins.position()
         p_expect = np.array([1.0, 2.0, 3.0])
@@ -134,8 +129,9 @@ class Test_BaseINS:
         assert p_out is not ins._p
         np.testing.assert_array_equal(p_out, p_expect)
 
-    def test_velocity(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_velocity(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         v_out = ins.velocity()
         v_expect = np.array([4.0, 5.0, 6.0])
@@ -144,8 +140,9 @@ class Test_BaseINS:
         assert v_out is not ins._v
         np.testing.assert_array_equal(v_out, v_expect)
 
-    def test_quaternion(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_quaternion(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         q_out = ins.quaternion()
         q_expect = np.array([1.0, 0.0, 0.0, 0.0])
@@ -154,8 +151,9 @@ class Test_BaseINS:
         assert q_out is not ins._q
         np.testing.assert_array_equal(q_out, q_expect)
 
-    def test_euler(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_euler(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         theta_out = ins.euler()
         theta_expect = np.array([0.0, 0.0, 0.0])
@@ -163,8 +161,9 @@ class Test_BaseINS:
         assert theta_out.shape == (3,)
         np.testing.assert_array_equal(theta_out, theta_expect)
 
-    def test_bias_acc(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_bias_acc(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         ba_out = ins.bias_acc()
         ba_expect = np.array([7.0, 8.0, 9.0])
@@ -173,8 +172,9 @@ class Test_BaseINS:
         assert ba_out is not ins._v
         np.testing.assert_array_equal(ba_out, ba_expect)
 
-    def test_bias_gyro(self, x0_nonzero):
-        ins = BaseINS(x0_nonzero)
+    def test_bias_gyro(self, x):
+        ins = INSMixin()
+        ins._x = x
 
         bg_out = ins.bias_gyro()
         bg_expect = np.array([10.0, 11.0, 12.0])
@@ -214,7 +214,7 @@ class Test_StrapdownINS:
     def test__init__(self, x0_nonzero):
         ins = StrapdownINS(x0_nonzero)
 
-        assert isinstance(ins, BaseINS)
+        assert isinstance(ins, INSMixin)
         np.testing.assert_array_equal(ins._x0, x0_nonzero)
         np.testing.assert_array_equal(ins._x, x0_nonzero)
 
@@ -648,7 +648,7 @@ class Test_AidedINS:
         ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
 
         assert isinstance(ains, AidedINS)
-        assert isinstance(ains, BaseINS)
+        assert isinstance(ains, INSMixin)
         assert ains._fs == 10.24
         assert ains._dt == 1.0 / 10.24
         assert ains._err_acc == err_acc

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -312,6 +312,65 @@ class Test_StrapdownINS:
         np.testing.assert_array_almost_equal(x0_out, x0_expect)
         np.testing.assert_array_almost_equal(x1_out, x1_expect)
 
+    def test_update_with_bias(self, x0):
+        ba = np.array([0.1, 0.2, 0.3])
+        bg = np.array([0.4, 0.5, 0.6])
+        x0[10:13] = ba
+        x0[13:16] = bg
+        ins = StrapdownINS(x0)
+        h = 0.1
+        g = ins._g
+        f = np.array([1.0, 2.0, 3.0]) + ba - g  # IMU measurements w/bias
+        w = np.array([0.04, 0.05, 0.06]) + bg  # IMU measurements w/bias
+
+        x0_out = ins.x
+        ins.update(h, f, w, degrees=False)
+        x1_out = ins.x
+
+        x0_expect = np.array(
+            [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.6,
+            ]
+        )
+        x1_expect = np.array(
+            [
+                0.005,
+                0.01,
+                0.015,
+                0.1,
+                0.2,
+                0.3,
+                0.99999,
+                0.002,
+                0.0025,
+                0.003,
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.6,
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(x0_out, x0_expect)
+        np.testing.assert_array_almost_equal(x1_out, x1_expect)
+
     def test_update_twise(self, ins):
         dt = 0.1
         g = ins._g

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -207,16 +207,52 @@ class Test_StrapdownINS:
     def test_update(self, ins):
         h = 0.1
         g = ins._g
-        f = np.array([1.0, 2.0, 3.0]).reshape(-1, 1) - g
-        w = np.array([0.04, 0.05, 0.06]).reshape(-1, 1)
+        f = np.array([1.0, 2.0, 3.0]) - g
+        w = np.array([0.04, 0.05, 0.06])
 
         x0_out = ins.x
         ins.update(h, f, w)
         x1_out = ins.x
 
-        x0_expect = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        x0_expect = np.array(
+            [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        )
         x1_expect = np.array(
-            [0.005, 0.01, 0.015, 0.1, 0.2, 0.3, 0.99999, 0.002, 0.0025, 0.003]
+            [
+                0.005,
+                0.01,
+                0.015,
+                0.1,
+                0.2,
+                0.3,
+                0.99999,
+                0.002,
+                0.0025,
+                0.003,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
         )
 
         np.testing.assert_array_almost_equal(x0_out, x0_expect)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -572,7 +572,8 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._var_vel, var_vel)
         np.testing.assert_array_almost_equal(ains._var_g, var_g)
         np.testing.assert_array_almost_equal(ains._var_compass, var_compass)
-        np.testing.assert_array_almost_equal(ains._x_ins, x0)
+        np.testing.assert_array_almost_equal(ains._x0, x0)
+        np.testing.assert_array_almost_equal(ains._x, x0)
         np.testing.assert_array_almost_equal(ains._P_prior, np.eye(15))
 
         assert ains._dfdx.shape == (15, 15)


### PR DESCRIPTION
### This PR is related to user story DLAB-77

## Description
Include biases in StrapdownINS state. Move some state related methods to an INS mixin class.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
