### PR TITLE
Mandatory initial error covariance matrix

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -560,6 +560,13 @@ class AidedINS(INSMixin):
         """
         return self._P.copy()
 
+    @property
+    def P_prior(self) -> NDArray[np.float64]:
+        """
+        Get next a priori estimate of the error covariance matrix, **P**.
+        """
+        return self._P.copy()
+
     @staticmethod
     def _prep_dfdx_matrix(
         err_acc: dict[str, float],

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -490,7 +490,7 @@ class AidedINS(INSMixin):
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
     P0 : array-like, shape (15, 15)
-        Initial a priori estimate of error covariance matrix, **P**. If in doubt, use
+        Initial a priori estimate of error covariance matrix, **P**. If uncertain, use
         a small diagonal matrix (e.g., `1e-6 * np.eye(15)`).
     err_acc : dict of {str: float}
         Dictionary containing accelerometer noise parameters with keys:
@@ -520,7 +520,7 @@ class AidedINS(INSMixin):
         self,
         fs: float,
         x0: ArrayLike,
-        P0: ArrayLike,
+        P0_prior: ArrayLike,
         err_acc: dict[str, float],
         err_gyro: dict[str, float],
         var_pos: ArrayLike,

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -489,9 +489,9 @@ class AidedINS(INSMixin):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0 : array-like, shape (15, 15)
+    P0_prior : array-like, shape (15, 15)
         Initial a priori estimate of error covariance matrix, **P**. If uncertain, use
-        a small diagonal matrix (e.g., `1e-6 * np.eye(15)`).
+        a small diagonal matrix (e.g., ``1e-6 * numpy.eye(15)``).
     err_acc : dict of {str: float}
         Dictionary containing accelerometer noise parameters with keys:
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -556,7 +556,8 @@ class AidedINS(INSMixin):
     @property
     def P(self) -> NDArray[np.float64]:
         """
-        Get current error covariance matrix, **P**.
+        Error covariance matrix, **P**, associated with the current updated
+        (a posteriori) error-state estimate.
         """
         return self._P.copy()
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -556,15 +556,18 @@ class AidedINS(INSMixin):
     @property
     def P(self) -> NDArray[np.float64]:
         """
-        Error covariance matrix, **P**, associated with the current updated
-        (a posteriori) error-state estimate.
+        Current updated error covariance matrix, **P**. I.e., the error covariance
+        matrix associated with the Kalman filter's updated (a posteriori) error-state
+        estimate.
         """
         return self._P.copy()
 
     @property
     def P_prior(self) -> NDArray[np.float64]:
         """
-        Get next a priori estimate of the error covariance matrix, **P**.
+        Next a priori estimate of the error covariance matrix, **P**. I.e., the error
+        covariance matrix associated with the Kalman filter's projected (a priori)
+        error-state estimate.
         """
         return self._P_prior.copy()
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -533,9 +533,9 @@ class AidedINS(INSMixin):
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()
-        self._P0 = np.asarray_chkfinite(P0).reshape(15, 15).copy()
-        self._P = self._P0.copy()
-        self._P_prior = self._P0.copy()
+        self._P0_prior = np.asarray_chkfinite(P0_prior).reshape(15, 15).copy()
+        self._P_prior = self._P0_prior.copy()
+        self._P = np.empty_like(self._P_prior)
         self._err_acc = err_acc
         self._err_gyro = err_gyro
         self._var_pos = np.asarray_chkfinite(var_pos).reshape(3).copy()

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -489,6 +489,9 @@ class AidedINS(INSMixin):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
+    P0 : array-like, shape (15, 15)
+        Initial a priori estimate of error covariance matrix, **P**. If in doubt, use
+        a small diagonal matrix (e.g., `1e-6 * np.eye(15)`).
     err_acc : dict of {str: float}
         Dictionary containing accelerometer noise parameters with keys:
 
@@ -509,8 +512,6 @@ class AidedINS(INSMixin):
         Variance of gravitational reference vector measurement noise in m^2.
     var_compass : float
         Variance of compass measurement noise in rad^2.
-    cov_error : array-like, shape (15, 15), optional, default identidy matrix
-        A priori estimate of error covariance matrix, **P**.
     """
 
     _I15 = np.eye(15)
@@ -519,19 +520,22 @@ class AidedINS(INSMixin):
         self,
         fs: float,
         x0: ArrayLike,
+        P0: ArrayLike,
         err_acc: dict[str, float],
         err_gyro: dict[str, float],
         var_pos: ArrayLike,
         var_vel: ArrayLike,
         var_g: ArrayLike,
         var_compass: float,
-        cov_error: ArrayLike | None = None,
     ) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()
+        self._P0 = np.asarray_chkfinite(P0).reshape(15, 15).copy()
+        self._P = self._P0.copy()
+        self._P_prior = self._P0.copy()
         self._err_acc = err_acc
         self._err_gyro = err_gyro
         self._var_pos = np.asarray_chkfinite(var_pos).reshape(3).copy()
@@ -541,13 +545,6 @@ class AidedINS(INSMixin):
 
         # Strapdown algorithm
         self._ins = StrapdownINS(self._x0)
-
-        # Initial Kalman filter error covariance
-        if cov_error is not None:
-            self._P_prior = np.asarray_chkfinite(cov_error).reshape(15, 15).copy()
-        else:
-            self._P_prior = np.eye(15)
-        self._P = self._P_prior.copy()
 
         # Prepare system matrices
         q0 = self._x0[6:10]

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -712,6 +712,23 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(quaternion_out, quaternion_expect)
         assert quaternion_out is not ains._q
 
+    def test_P_prior(self, ains):
+        P_prior_out = ains.P_prior
+        P_prior_expect = 1e-6 * np.eye(15)
+
+        np.testing.assert_array_almost_equal(P_prior_out, P_prior_expect)
+        assert P_prior_out is not ains._P_prior
+
+    def test_P(self, ains):
+        P = np.random.random((15, 15))
+        ains._P = P
+
+        P_out = ains.P
+        P_expect = P
+
+        np.testing.assert_array_almost_equal(P_out, P_expect)
+        assert P_out is not ains._P
+
     def test__prep_dfdx_matrix(self):
         err_acc = {"N": 4.0e-4, "B": 2.0e-4, "tau_cb": 50}
         err_gyro = {

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -912,7 +912,9 @@ class Test_AidedINS:
         var_g = np.ones(3)
         var_compass = 1.0
 
-        ains = AidedINS(fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
+        ains = AidedINS(
+            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+        )
 
         g = gravity()
         f_imu = np.array([0.0, 0.0, -g])
@@ -1032,8 +1034,8 @@ class Test_AidedINS:
         var_vel = vel_noise_std**2 * np.ones(3)
         var_compass = ((np.pi / 180.0) * compass_noise_std) ** 2
         var_g = 0.1**2 * np.ones(3)
-        P_prior = np.eye(15)
-        P_prior[9:12, 9:12] *= 1e-9
+        P0_prior = np.eye(15)
+        P0_prior[9:12, 9:12] *= 1e-9
         x0 = np.zeros(16)
         x0[0:3] = pos_ref[0]
         x0[3:6] = vel_ref[0]
@@ -1041,13 +1043,13 @@ class Test_AidedINS:
         mekf = AidedINS(
             fs_imu,
             x0,
+            P0_prior,
             err_acc,
             err_gyro,
             var_pos,
             var_vel,
             var_g,
             var_compass,
-            cov_error=P_prior,
         )
 
         # Apply filter

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -874,6 +874,7 @@ class Test_AidedINS:
 
         x0 = np.zeros(16)
         x0[6] = 1.0
+        P0 = 1e-6 * np.eye(15)
 
         err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
         err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
@@ -882,7 +883,9 @@ class Test_AidedINS:
         var_g = np.ones(3)
         var_compass = 1.0
 
-        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
+        ains = AidedINS(
+            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+        )
 
         g = gravity()
         f_imu = np.array([0.0, 0.0, -g])
@@ -900,6 +903,7 @@ class Test_AidedINS:
 
         x0 = np.zeros(16)
         x0[6] = 1.0
+        P0 = 1e-6 * np.eye(15)
 
         err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
         err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
@@ -908,7 +912,7 @@ class Test_AidedINS:
         var_g = np.ones(3)
         var_compass = 1.0
 
-        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
+        ains = AidedINS(fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
 
         g = gravity()
         f_imu = np.array([0.0, 0.0, -g])

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -648,8 +648,8 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._x0, x0)
         np.testing.assert_array_almost_equal(ains._x, x0)
         np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)
-        np.testing.assert_array_almost_equal(ains._P, P0_prior)
         np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)
+        assert ains._P.shape == (15, 15)
 
         assert ains._dfdx.shape == (15, 15)
         assert ains._dfdw.shape == (15, 12)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -586,7 +586,7 @@ class Test_AidedINS:
         bias_gyro_init = np.array([-0.1, 0.0, 0.0])
 
         x0 = np.r_[p_init, v_init, q_init, bias_acc_init, bias_gyro_init]
-        P0 = 1e-6 * np.eye(15)
+        P0_prior = 1e-6 * np.eye(15)
 
         err_acc = {"N": 4.0e-4, "B": 2.0e-4, "tau_cb": 50}
         err_gyro = {
@@ -601,7 +601,7 @@ class Test_AidedINS:
         var_compass = ((np.pi / 180.0) * 0.5) ** 2
 
         ains = AidedINS(
-            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
         )
         return ains
 
@@ -615,7 +615,7 @@ class Test_AidedINS:
         bias_gyro_init = np.array([0.0, 0.0, 0.0])
 
         x0 = np.r_[p_init, v_init, q_init, bias_acc_init, bias_gyro_init]
-        P0 = 1e-6 * np.eye(15)
+        P0_prior = 1e-6 * np.eye(15)
 
         err_acc = {"N": 4.0e-4, "B": 2.0e-4, "tau_cb": 50}
         err_gyro = {
@@ -630,7 +630,7 @@ class Test_AidedINS:
         var_compass = ((np.pi / 180.0) * 0.5) ** 2
 
         ains = AidedINS(
-            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
         )
 
         assert isinstance(ains, AidedINS)
@@ -647,9 +647,9 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._var_compass, var_compass)
         np.testing.assert_array_almost_equal(ains._x0, x0)
         np.testing.assert_array_almost_equal(ains._x, x0)
-        np.testing.assert_array_almost_equal(ains._P0, P0)
-        np.testing.assert_array_almost_equal(ains._P, P0)
-        np.testing.assert_array_almost_equal(ains._P_prior, P0)
+        np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)
+        np.testing.assert_array_almost_equal(ains._P, P0_prior)
+        np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)
 
         assert ains._dfdx.shape == (15, 15)
         assert ains._dfdw.shape == (15, 12)
@@ -874,7 +874,7 @@ class Test_AidedINS:
 
         x0 = np.zeros(16)
         x0[6] = 1.0
-        P0 = 1e-6 * np.eye(15)
+        P0_prior = 1e-6 * np.eye(15)
 
         err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
         err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
@@ -884,7 +884,7 @@ class Test_AidedINS:
         var_compass = 1.0
 
         ains = AidedINS(
-            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
         )
 
         g = gravity()
@@ -903,7 +903,7 @@ class Test_AidedINS:
 
         x0 = np.zeros(16)
         x0[6] = 1.0
-        P0 = 1e-6 * np.eye(15)
+        P0_prior = 1e-6 * np.eye(15)
 
         err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
         err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
@@ -913,7 +913,7 @@ class Test_AidedINS:
         var_compass = 1.0
 
         ains = AidedINS(
-            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
         )
 
         g = gravity()

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -586,6 +586,7 @@ class Test_AidedINS:
         bias_gyro_init = np.array([-0.1, 0.0, 0.0])
 
         x0 = np.r_[p_init, v_init, q_init, bias_acc_init, bias_gyro_init]
+        P0 = 1e-6 * np.eye(15)
 
         err_acc = {"N": 4.0e-4, "B": 2.0e-4, "tau_cb": 50}
         err_gyro = {
@@ -599,7 +600,9 @@ class Test_AidedINS:
         var_g = (0.1) ** 2 * np.ones(3)
         var_compass = ((np.pi / 180.0) * 0.5) ** 2
 
-        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
+        ains = AidedINS(
+            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+        )
         return ains
 
     def test__init__(self):
@@ -612,6 +615,7 @@ class Test_AidedINS:
         bias_gyro_init = np.array([0.0, 0.0, 0.0])
 
         x0 = np.r_[p_init, v_init, q_init, bias_acc_init, bias_gyro_init]
+        P0 = 1e-6 * np.eye(15)
 
         err_acc = {"N": 4.0e-4, "B": 2.0e-4, "tau_cb": 50}
         err_gyro = {
@@ -625,7 +629,9 @@ class Test_AidedINS:
         var_g = (0.1) ** 2 * np.ones(3)
         var_compass = ((np.pi / 180.0) * 0.5) ** 2
 
-        ains = AidedINS(fs, x0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass)
+        ains = AidedINS(
+            fs, x0, P0, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+        )
 
         assert isinstance(ains, AidedINS)
         assert isinstance(ains, INSMixin)
@@ -641,7 +647,9 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._var_compass, var_compass)
         np.testing.assert_array_almost_equal(ains._x0, x0)
         np.testing.assert_array_almost_equal(ains._x, x0)
-        np.testing.assert_array_almost_equal(ains._P_prior, np.eye(15))
+        np.testing.assert_array_almost_equal(ains._P0, P0)
+        np.testing.assert_array_almost_equal(ains._P, P0)
+        np.testing.assert_array_almost_equal(ains._P_prior, P0)
 
         assert ains._dfdx.shape == (15, 15)
         assert ains._dfdw.shape == (15, 12)


### PR DESCRIPTION
### This PR is related to user story DLAB-80

## Description
Make the initial error covariance matrix mandatory.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
