### PR TITLE
Included latitude in AidedINS

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -514,6 +514,9 @@ class AidedINS(INSMixin):
         Variance of gravitational reference vector measurement noise in m^2.
     var_compass : float
         Variance of compass measurement noise in rad^2.
+    lat : float, optional
+        Latitude used to calculate the gravitational acceleration. If none
+        provided, the 'standard gravity' is assumed.
     """
 
     _I15 = np.eye(15)
@@ -529,6 +532,7 @@ class AidedINS(INSMixin):
         var_vel: ArrayLike,
         var_g: ArrayLike,
         var_compass: float,
+        lat: float | None = None,
     ) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
@@ -546,7 +550,7 @@ class AidedINS(INSMixin):
         self._var_compass = np.asarray_chkfinite(var_compass).reshape(1).copy()
 
         # Strapdown algorithm
-        self._ins = StrapdownINS(self._fs, self._x0)
+        self._ins = StrapdownINS(self._fs, self._x0, lat=lat)
 
         # Prepare system matrices
         q0 = self._x0[6:10]

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -623,7 +623,16 @@ class Test_AidedINS:
         var_compass = ((np.pi / 180.0) * 0.5) ** 2
 
         ains = AidedINS(
-            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs,
+            x0,
+            P0_prior,
+            err_acc,
+            err_gyro,
+            var_pos,
+            var_vel,
+            var_g,
+            var_compass,
+            lat=60.0,
         )
 
         assert isinstance(ains, AidedINS)
@@ -643,6 +652,10 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)
         np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)
         assert ains._P.shape == (15, 15)
+
+        # Check that correct latitude (and thus gravity) is used
+        g_expect = np.array([0.0, 0.0, gravity(60.0)])
+        np.testing.assert_array_almost_equal(ains._ins._g, g_expect)
 
         assert ains._dfdx.shape == (15, 15)
         assert ains._dfdw.shape == (15, 12)


### PR DESCRIPTION
### This PR is related to user story DLAB-85

## Description
Included latitude in AidedINS so that it can be passed on to StrapdownINS.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
