### PR TITLE
Accept aiding variances in update

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -756,8 +756,8 @@ class AidedINS(INSMixin):
             Variance of velocity measurement noise in (m/s)^2.
         var_g : array-like, shape (3,), optional
             Variance of gravitational reference vector measurement noise in m^2.
-        var_compass : float, optional
-            Variance of compass measurement noise in rad^2.
+        var_head : float, optional
+            Variance of heading measurement noise in rad^2.
 
         Returns
         -------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -812,7 +812,7 @@ class AidedINS(INSMixin):
             delta_pos = pos - p_ins
 
             if var_pos is not None:
-                var_pos = np.asarray_chkfinite(var_pos).reshape(3).copy()
+                var_pos = np.asarray_chkfinite(var_pos, dtype=float).reshape(3).copy()
             elif self._var_pos is not None:
                 var_pos = self._var_pos
             else:
@@ -828,28 +828,28 @@ class AidedINS(INSMixin):
             delta_vel = vel - v_ins
 
             if var_vel is not None:
-                var_vel = np.asarray_chkfinite(var_vel).reshape(3).copy()
+                var_vel = np.asarray_chkfinite(var_vel, dtype=float).reshape(3).copy()
             elif self._var_vel is not None:
                 var_vel = self._var_vel
             else:
                 raise ValueError("'var_vel' not provided.")
 
             dz_temp.append(delta_vel)
-            var_z_temp.append(self._var_vel)
+            var_z_temp.append(var_vel)
             dhdx_temp.append(dhdx_[3:6])
 
         # Gravity reference vector aiding
         delta_g = v1 - R_bn.T @ v01
 
         if var_g is not None:
-            var_g = np.asarray_chkfinite(var_g).reshape(3).copy()
+            var_g = np.asarray_chkfinite(var_g, dtype=float).reshape(3).copy()
         elif self._var_g is not None:
             var_g = self._var_g
         else:
             raise ValueError("'var_g' not provided.")
 
         dz_temp.append(delta_g)
-        var_z_temp.append(self._var_g)
+        var_z_temp.append(var_g)
         dhdx_temp.append(dhdx_[6:9])
 
         # Compass aiding
@@ -859,14 +859,14 @@ class AidedINS(INSMixin):
             delta_head = _signed_smallest_angle(head - _h(_gibbs(q_ins)), degrees=False)
 
             if var_head is not None:
-                var_head = np.asarray_chkfinite(var_head).reshape(1).copy()
+                var_head = np.asarray_chkfinite(var_head, dtype=float).reshape(1).copy()
             elif self._var_head is not None:
                 var_head = self._var_head
             else:
                 raise ValueError("'var_head' not provided.")
 
             dz_temp.append(np.array([delta_head]))
-            var_z_temp.append(self._var_head)
+            var_z_temp.append(var_head)
             dhdx_temp.append(dhdx_[-1:])
 
         dz = np.concatenate(dz_temp, axis=0)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -588,14 +588,9 @@ class Test_AidedINS:
             "tau_cb": 50,
         }
 
-        var_pos = [0.1, 0.1, 0.1]
-        var_vel = [0.1, 0.1, 0.1]
-        var_g = (0.1) ** 2 * np.ones(3)
-        var_head = ((np.pi / 180.0) * 0.5) ** 2
+        var_g = (0.1) ** 2 * np.ones(3)  # other variances must be given during update
 
-        ains = AidedINS(
-            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_head
-        )
+        ains = AidedINS(fs, x0, P0_prior, err_acc, err_gyro, var_g=var_g)
         return ains
 
     def test__init__(self):
@@ -921,9 +916,22 @@ class Test_AidedINS:
         head = 0.0
         pos = np.zeros(3)
         vel = np.zeros(3)
+        var_pos = np.ones(3)
+        var_vel = np.ones(3)
+        var_head = 1.0
 
         update_return = ains.update(
-            f_imu, w_imu, pos, vel, head, degrees=True, head_degrees=True
+            f_imu,
+            w_imu,
+            pos,
+            vel,
+            head,
+            degrees=True,
+            head_degrees=True,
+            var_pos=var_pos,
+            var_vel=var_vel,
+            var_g=None,  # provided in __init__
+            var_head=var_head,
         )
         assert update_return is ains
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1089,10 +1089,10 @@ class Test_AidedINS:
         var_pos = np.ones(3)
         var_vel = np.ones(3)
         var_g = np.ones(3)
-        var_compass = 1.0
+        var_head = 1.0
 
         ains = AidedINS(
-            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_head
         )
 
         g = gravity()
@@ -1118,10 +1118,10 @@ class Test_AidedINS:
         var_pos = np.ones(3)
         var_vel = np.ones(3)
         var_g = np.ones(3)
-        var_compass = 1.0
+        var_head = 1.0
 
         ains = AidedINS(
-            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_head
         )
 
         g = gravity()

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -7,7 +7,6 @@ operates with active rotations, whereas passive rotations are considered here. K
 mind that passive rotations is simply the inverse active rotations and vice versa.
 """
 
-
 from pathlib import Path
 
 import numpy as np

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -927,6 +927,110 @@ class Test_AidedINS:
         )
         assert update_return is ains
 
+    def test_update_var(self):
+        """Update using aiding variances given in __init__ or update method."""
+        fs = 10.24
+
+        x0 = np.zeros(16)
+        x0[6] = 1.0
+        P0_prior = 1e-6 * np.eye(15)
+
+        err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
+        err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
+        var_pos = np.ones(3)
+        var_vel = np.ones(3)
+        var_g = np.ones(3)
+        var_head = 1.0
+
+        # Aiding variances given in __init__
+        ains_a = AidedINS(
+            fs,
+            x0,
+            P0_prior,
+            err_acc,
+            err_gyro,
+            var_pos=var_pos,
+            var_vel=var_vel,
+            var_g=var_g,
+            var_head=var_head,
+        )
+
+        # Aiding variances given during update
+        ains_b = AidedINS(
+            fs,
+            x0,
+            P0_prior,
+            err_acc,
+            err_gyro,
+            var_pos=None,
+            var_vel=None,
+            var_g=None,
+            var_head=None,
+        )
+
+        # Aiding variances given in both __init__ and update
+        ains_c = AidedINS(
+            fs,
+            x0,
+            P0_prior,
+            err_acc,
+            err_gyro,
+            var_pos=var_pos,
+            var_vel=var_vel,
+            var_g=var_g,
+            var_head=var_head,
+        )
+
+        g = gravity()
+        f_imu = np.array([0.0, 0.0, -g])
+        w_imu = np.zeros(3)
+        head = 0.0
+        pos = np.zeros(3)
+        vel = np.zeros(3)
+
+        for _ in range(5):
+            ains_a.update(
+                f_imu,
+                w_imu,
+                pos,
+                vel,
+                head,
+                degrees=True,
+                head_degrees=True,
+                var_pos=None,
+                var_vel=None,
+                var_g=None,
+                var_head=None,
+            )
+            ains_b.update(
+                f_imu,
+                w_imu,
+                pos,
+                vel,
+                head,
+                degrees=True,
+                head_degrees=True,
+                var_pos=var_pos,
+                var_vel=var_vel,
+                var_g=var_g,
+                var_head=var_head,
+            )
+            ains_c.update(
+                f_imu,
+                w_imu,
+                pos,
+                vel,
+                head,
+                degrees=True,
+                head_degrees=True,
+                var_pos=var_pos,
+                var_vel=var_vel,
+                var_g=var_g,
+                var_head=var_head,
+            )
+            np.testing.assert_array_almost_equal(ains_a.x, ains_b.x)
+            np.testing.assert_array_almost_equal(ains_a.x, ains_c.x)
+
     def test_update_standstill(self):
         fs = 10.24
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1031,6 +1031,52 @@ class Test_AidedINS:
             np.testing.assert_array_almost_equal(ains_a.x, ains_b.x)
             np.testing.assert_array_almost_equal(ains_a.x, ains_c.x)
 
+    def test_update_var_raises(self):
+        """Update using aiding variances given in __init__ or update method."""
+        fs = 10.24
+
+        x0 = np.zeros(16)
+        x0[6] = 1.0
+        P0_prior = 1e-6 * np.eye(15)
+
+        err_acc = {"N": 0.01, "B": 0.002, "tau_cb": 1000.0}
+        err_gyro = {"N": 0.03, "B": 0.004, "tau_cb": 2000.0}
+
+        # Aiding variances given in __init__
+        ains = AidedINS(
+            fs,
+            x0,
+            P0_prior,
+            err_acc,
+            err_gyro,
+            var_pos=None,  # no aiding variance provided
+            var_vel=None,  # no aiding variance provided
+            var_g=None,  # no aiding variance provided
+            var_head=None,  # no aiding variance provided
+        )
+
+        g = gravity()
+        f_imu = np.array([0.0, 0.0, -g])
+        w_imu = np.zeros(3)
+        head = 0.0
+        pos = np.zeros(3)
+        vel = np.zeros(3)
+
+        with pytest.raises(ValueError):
+            ains.update(
+                f_imu,
+                w_imu,
+                pos,
+                vel,
+                head,
+                degrees=True,
+                head_degrees=True,
+                var_pos=None,  # no aiding variance provided
+                var_vel=None,  # no aiding variance provided
+                var_g=None,  # no aiding variance provided
+                var_head=None,  # no aiding variance provided
+            )
+
     def test_update_standstill(self):
         fs = 10.24
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1240,7 +1240,7 @@ class Test_AidedINS:
         }
         var_pos = gps_noise_std**2 * np.ones(3)
         var_vel = vel_noise_std**2 * np.ones(3)
-        var_compass = ((np.pi / 180.0) * compass_noise_std) ** 2
+        var_head = ((np.pi / 180.0) * compass_noise_std) ** 2
         var_g = 0.1**2 * np.ones(3)
         P0_prior = np.eye(15)
         P0_prior[9:12, 9:12] *= 1e-9
@@ -1254,10 +1254,10 @@ class Test_AidedINS:
             P0_prior,
             err_acc,
             err_gyro,
-            var_pos,
-            var_vel,
-            var_g,
-            var_compass,
+            var_pos=np.ones_like(var_pos) * 1e9,  # correct values given in update
+            var_vel=np.ones_like(var_vel) * 1e9,  # correct values given in update
+            var_g=var_g,
+            var_head=None,  # provided during update
         )
 
         # Apply filter
@@ -1274,6 +1274,10 @@ class Test_AidedINS:
                     head=head_i,
                     degrees=True,
                     head_degrees=True,
+                    var_pos=var_pos,  # provided in __init__ but overridden here
+                    var_vel=var_vel,  # provided in __init__ but overridden here
+                    var_g=None,  # provided in __init__
+                    var_head=var_head,
                 )
             else:  # without aiding
                 mekf.update(acc_i, gyro_i, degrees=True, head_degrees=True)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -591,10 +591,10 @@ class Test_AidedINS:
         var_pos = [0.1, 0.1, 0.1]
         var_vel = [0.1, 0.1, 0.1]
         var_g = (0.1) ** 2 * np.ones(3)
-        var_compass = ((np.pi / 180.0) * 0.5) ** 2
+        var_head = ((np.pi / 180.0) * 0.5) ** 2
 
         ains = AidedINS(
-            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_compass
+            fs, x0, P0_prior, err_acc, err_gyro, var_pos, var_vel, var_g, var_head
         )
         return ains
 
@@ -620,7 +620,7 @@ class Test_AidedINS:
         var_pos = [0.1, 0.1, 0.1]
         var_vel = [0.1, 0.1, 0.1]
         var_g = (0.1) ** 2 * np.ones(3)
-        var_compass = ((np.pi / 180.0) * 0.5) ** 2
+        var_head = ((np.pi / 180.0) * 0.5) ** 2
 
         ains = AidedINS(
             fs,
@@ -631,7 +631,7 @@ class Test_AidedINS:
             var_pos,
             var_vel,
             var_g,
-            var_compass,
+            var_head,
             lat=60.0,
         )
 
@@ -646,7 +646,7 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains._var_pos, var_pos)
         np.testing.assert_array_almost_equal(ains._var_vel, var_vel)
         np.testing.assert_array_almost_equal(ains._var_g, var_g)
-        np.testing.assert_array_almost_equal(ains._var_compass, var_compass)
+        np.testing.assert_array_almost_equal(ains._var_head, var_head)
         np.testing.assert_array_almost_equal(ains._x0, x0)
         np.testing.assert_array_almost_equal(ains._x, x0)
         np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1032,7 +1032,7 @@ class Test_AidedINS:
             np.testing.assert_array_almost_equal(ains_a.x, ains_c.x)
 
     def test_update_var_raises(self):
-        """Update using aiding variances given in __init__ or update method."""
+        """Chack that update raise ValueError if no aiding variances are provided."""
         fs = 10.24
 
         x0 = np.zeros(16)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,6 @@ operates with active rotations, whereas passive rotations are considered here. K
 mind that passive rotations is simply the inverse active rotations and vice versa.
 """
 
-
 import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation

--- a/tests/test_vectorops.py
+++ b/tests/test_vectorops.py
@@ -7,7 +7,6 @@ operates with active rotations, whereas passive rotations are considered here. K
 mind that passive rotations is simply the inverse active rotations and vice versa.
 """
 
-
 import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation


### PR DESCRIPTION
### This PR is related to user story DLAB-81

## Description
Refactored MEKF to allow aiding variances to be given in either init or update.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
