### PR TITLE
Make gravity vector aiding optional

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -710,6 +710,7 @@ class AidedINS(INSMixin):
         pos: ArrayLike | None = None,
         vel: ArrayLike | None = None,
         head: float | None = None,
+        g_ref: bool = False,
         degrees: bool = False,
         head_degrees: bool = True,
         var_pos: ArrayLike | None = None,
@@ -736,6 +737,8 @@ class AidedINS(INSMixin):
             Velocity aiding measurement. If ``None``, velocity aiding is not used.
         head : float, optional
             Heading measurement, i.e., yaw angle. If ``None``, compass aiding is not used.
+        g_ref : bool, optional
+            Specifies whether the gravity reference vector is used as an aiding measurement.
         degrees : bool, default False
             Specifies whether the unit of ``w_imu`` are in degrees or radians.
         head_degrees : bool, default True
@@ -815,20 +818,21 @@ class AidedINS(INSMixin):
             H_temp.append(self._H[3:6])
 
         # Gravity reference vector aiding
-        vg_ref_n = np.array([0.0, 0.0, 1.0])
-        vg_meas_m = -_normalize(f_ins)
-        delta_g = vg_meas_m - R_ins_nm.T @ vg_ref_n
+        if g_ref:
+            vg_ref_n = np.array([0.0, 0.0, 1.0])
+            vg_meas_m = -_normalize(f_ins)
+            delta_g = vg_meas_m - R_ins_nm.T @ vg_ref_n
 
-        if var_g is not None:
-            var_g = np.asarray_chkfinite(var_g, dtype=float).reshape(3).copy()
-        elif self._var_g is not None:
-            var_g = self._var_g
-        else:
-            raise ValueError("'var_g' not provided.")
+            if var_g is not None:
+                var_g = np.asarray_chkfinite(var_g, dtype=float).reshape(3).copy()
+            elif self._var_g is not None:
+                var_g = self._var_g
+            else:
+                raise ValueError("'var_g' not provided.")
 
-        dz_temp.append(delta_g)
-        var_z_temp.append(var_g)
-        H_temp.append(self._H[6:9])
+            dz_temp.append(delta_g)
+            var_z_temp.append(var_g)
+            H_temp.append(self._H[6:9])
 
         # Compass aiding
         if head is not None:
@@ -849,38 +853,41 @@ class AidedINS(INSMixin):
             var_z_temp.append(var_head)
             H_temp.append(self._H[-1:])
 
-        dz = np.concatenate(dz_temp, axis=0)
-        H = np.concatenate(H_temp, axis=0)
-        R = np.diag(np.concatenate(var_z_temp, axis=0))
+        if len(dz_temp) != 0:
+            dz = np.concatenate(dz_temp, axis=0)
+            H = np.concatenate(H_temp, axis=0)
+            R = np.diag(np.concatenate(var_z_temp, axis=0))
+
+            # Compute Kalman gain
+            K = self._P_prior @ H.T @ inv(H @ self._P_prior @ H.T + R)
+
+            # Update error-state estimate with measurement
+            dx = K @ dz
+
+            # Compute error covariance for updated estimate
+            self._P = (self._I15 - K @ H) @ self._P_prior @ (
+                self._I15 - K @ H
+            ).T + K @ R @ K.T
+
+            # Error quaternion from 2x Gibbs vector
+            da = dx[6:9]
+            dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
+
+            # Reset
+            pos_ins = pos_ins + dx[0:3]
+            vel_ins = vel_ins + dx[3:6]
+            q_ins_nm = _quaternion_product(q_ins_nm, dq)
+            q_ins_nm = _normalize(q_ins_nm)
+            bias_acc_ins = bias_acc_ins + dx[9:12]
+            bias_gyro_ins = bias_gyro_ins + dx[12:15]
+            x_ins = np.r_[pos_ins, vel_ins, q_ins_nm, bias_acc_ins, bias_gyro_ins]
+            self._ins.reset(x_ins)
+        else:
+            self._P = self._P_prior
 
         # Discretize system
         phi = self._I15 + self._dt * self._F  # state transition matrix
         Q = self._dt * self._G @ self._W @ self._G.T  # process noise covariance matrix
-
-        # Compute Kalman gain
-        K = self._P_prior @ H.T @ inv(H @ self._P_prior @ H.T + R)
-
-        # Update error-state estimate with measurement
-        dx = K @ dz
-
-        # Compute error covariance for updated estimate
-        self._P = (self._I15 - K @ H) @ self._P_prior @ (
-            self._I15 - K @ H
-        ).T + K @ R @ K.T
-
-        # Error quaternion from 2x Gibbs vector
-        da = dx[6:9]
-        dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
-
-        # Reset
-        pos_ins = pos_ins + dx[0:3]
-        vel_ins = vel_ins + dx[3:6]
-        q_ins_nm = _quaternion_product(q_ins_nm, dq)
-        q_ins_nm = _normalize(q_ins_nm)
-        bias_acc_ins = bias_acc_ins + dx[9:12]
-        bias_gyro_ins = bias_gyro_ins + dx[12:15]
-        x_ins = np.r_[pos_ins, vel_ins, q_ins_nm, bias_acc_ins, bias_gyro_ins]
-        self._ins.reset(x_ins)
 
         # Project ahead
         self._ins.update(f_imu, w_imu, degrees=False)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -853,7 +853,7 @@ class AidedINS(INSMixin):
             var_z_temp.append(var_head)
             H_temp.append(self._H[-1:])
 
-        if len(dz_temp) > 0:
+        if dz_temp:
             dz = np.concatenate(dz_temp, axis=0)
             H = np.concatenate(H_temp, axis=0)
             R = np.diag(np.concatenate(var_z_temp, axis=0))

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -853,7 +853,7 @@ class AidedINS(INSMixin):
             var_z_temp.append(var_head)
             H_temp.append(self._H[-1:])
 
-        if len(dz_temp) != 0:
+        if len(dz_temp) > 0:
             dz = np.concatenate(dz_temp, axis=0)
             H = np.concatenate(H_temp, axis=0)
             R = np.diag(np.concatenate(var_z_temp, axis=0))
@@ -882,7 +882,7 @@ class AidedINS(INSMixin):
             bias_gyro_ins = bias_gyro_ins + dx[12:15]
             x_ins = np.r_[pos_ins, vel_ins, q_ins_nm, bias_acc_ins, bias_gyro_ins]
             self._ins.reset(x_ins)
-        else:
+        else:  # no aiding measurements
             self._P = self._P_prior
 
         # Discretize system

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -737,7 +737,7 @@ class AidedINS(INSMixin):
             Velocity aiding measurement. If ``None``, velocity aiding is not used.
         head : float, optional
             Heading measurement, i.e., yaw angle. If ``None``, compass aiding is not used.
-        g_ref : bool, optional
+        g_ref : bool, optional, default False
             Specifies whether the gravity reference vector is used as an aiding measurement.
         degrees : bool, default False
             Specifies whether the unit of ``w_imu`` are in degrees or radians.

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1285,6 +1285,7 @@ class Test_AidedINS:
                     pos=pos_i,
                     vel=vel_i,
                     head=head_i,
+                    g_ref=True,
                     degrees=True,
                     head_degrees=True,
                     var_pos=var_pos,  # provided in __init__ but overridden here

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1144,27 +1144,79 @@ class Test_AidedINS:
         pos = np.zeros(3)
         vel = np.zeros(3)
 
-        ains.update(f_imu, w_imu, pos, vel, head, degrees=True, head_degrees=True)
+        ains.update(f_imu, w_imu, pos, vel, head, True, degrees=True, head_degrees=True)
         np.testing.assert_array_almost_equal(ains.x, x0)
 
         ains.update(
-            f_imu, w_imu, pos=None, vel=None, head=None, degrees=True, head_degrees=True
+            f_imu,
+            w_imu,
+            pos=None,
+            vel=None,
+            head=None,
+            g_ref=False,
+            degrees=True,
+            head_degrees=True,
         )
         np.testing.assert_array_almost_equal(ains.x, x0)
 
         ains.update(
-            f_imu, w_imu, pos=None, vel=vel, head=head, degrees=True, head_degrees=True
+            f_imu,
+            w_imu,
+            pos=pos,
+            vel=vel,
+            head=head,
+            g_ref=True,
+            degrees=True,
+            head_degrees=True,
         )
         np.testing.assert_array_almost_equal(ains.x, x0)
 
         ains.update(
-            f_imu, w_imu, pos=pos, vel=None, head=head, degrees=True, head_degrees=True
+            f_imu,
+            w_imu,
+            pos=None,
+            vel=vel,
+            head=head,
+            g_ref=False,
+            degrees=True,
+            head_degrees=True,
         )
         np.testing.assert_array_almost_equal(ains.x, x0)
 
         ains.update(
-            f_imu, w_imu, pos=None, vel=None, head=head, degrees=True, head_degrees=True
+            f_imu,
+            w_imu,
+            pos=pos,
+            vel=None,
+            head=head,
+            g_ref=False,
+            degrees=True,
+            head_degrees=True,
         )
+        np.testing.assert_array_almost_equal(ains.x, x0)
+
+        ains.update(
+            f_imu,
+            w_imu,
+            pos=None,
+            vel=None,
+            head=head,
+            g_ref=False,
+            degrees=True,
+            head_degrees=True,
+        )
+
+        ains.update(
+            f_imu,
+            w_imu,
+            pos=None,
+            vel=None,
+            head=None,
+            g_ref=True,
+            degrees=True,
+            head_degrees=True,
+        )
+
         np.testing.assert_array_almost_equal(ains.x, x0)
 
     @pytest.mark.parametrize(

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1008,6 +1008,7 @@ class Test_AidedINS:
                 pos,
                 vel,
                 head,
+                g_ref=True,
                 degrees=True,
                 head_degrees=True,
                 var_pos=None,
@@ -1021,6 +1022,7 @@ class Test_AidedINS:
                 pos,
                 vel,
                 head,
+                g_ref=True,
                 degrees=True,
                 head_degrees=True,
                 var_pos=var_pos,
@@ -1034,6 +1036,7 @@ class Test_AidedINS:
                 pos,
                 vel,
                 head,
+                g_ref=True,
                 degrees=True,
                 head_degrees=True,
                 var_pos=var_pos,
@@ -1082,6 +1085,7 @@ class Test_AidedINS:
                 pos,
                 vel,
                 head,
+                g_ref=True,
                 degrees=True,
                 head_degrees=True,
                 var_pos=None,  # no aiding variance provided
@@ -1116,7 +1120,16 @@ class Test_AidedINS:
         vel = np.zeros(3)
 
         for _ in range(5):
-            ains.update(f_imu, w_imu, pos, vel, head, degrees=True, head_degrees=True)
+            ains.update(
+                f_imu,
+                w_imu,
+                pos,
+                vel,
+                head,
+                g_ref=True,
+                degrees=True,
+                head_degrees=True,
+            )
             np.testing.assert_array_almost_equal(ains.x, x0)
 
     def test_update_irregular_aiding(self):


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
Make gravity vector aiding as optional by introducing a `g_ref` boolean flag.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
