### PR TITLE
Make resetting of bias terms optional

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -819,20 +819,20 @@ class AidedINS(INSMixin):
         # Current INS state estimates
         pos_ins = self._ins._pos
         vel_ins = self._ins._vel
-        q_ins_nm = self._ins._q_nm
+        q_nm_ins = self._ins._q_nm
         bias_acc_ins = self._ins._bias_acc
         bias_gyro_ins = self._ins._bias_gyro
 
-        R_ins_nm = _rot_matrix_from_quaternion(q_ins_nm)  # body-to-ned rotation matrix
+        R_nm_ins = _rot_matrix_from_quaternion(q_nm_ins)  # body-to-ned rotation matrix
 
         # Bias compensated IMU measurements
         f_ins = f_imu - bias_acc_ins
         w_ins = w_imu - bias_gyro_ins
 
         # Update system matrices
-        self._update_F(q_ins_nm, f_ins, w_ins)
-        self._update_G(q_ins_nm)
-        self._update_H(q_ins_nm)
+        self._update_F(q_nm_ins, f_ins, w_ins)
+        self._update_G(q_nm_ins)
+        self._update_H(q_nm_ins)
 
         # Position aiding
         dz_temp, var_z_temp, H_temp = [], [], []
@@ -871,7 +871,7 @@ class AidedINS(INSMixin):
         if g_ref:
             vg_ref_n = np.array([0.0, 0.0, 1.0])
             vg_meas_m = -_normalize(f_imu - self._bias_acc)
-            delta_g = vg_meas_m - R_ins_nm.T @ vg_ref_n
+            delta_g = vg_meas_m - R_nm_ins.T @ vg_ref_n
 
             if var_g is not None:
                 var_g = np.asarray_chkfinite(var_g, dtype=float).reshape(3).copy()
@@ -889,7 +889,7 @@ class AidedINS(INSMixin):
             if head_degrees:
                 head = (np.pi / 180.0) * head
             delta_head = _signed_smallest_angle(
-                head - _h_head(_gibbs_scaled(q_ins_nm)), degrees=False
+                head - _h_head(_gibbs_scaled(q_nm_ins)), degrees=False
             )
 
             if var_head is not None:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -864,7 +864,7 @@ class AidedINS(INSMixin):
             K = self._P_prior @ H.T @ inv(H @ self._P_prior @ H.T + R)
 
             # Update error-state estimate with measurement
-            dx = self._dx_prior + K @ dz
+            self._dx = self._dx_prior + K @ dz
 
             # Compute error covariance for updated estimate
             self._P = (self._I15 - K @ H) @ self._P_prior @ (
@@ -872,12 +872,12 @@ class AidedINS(INSMixin):
             ).T + K @ R @ K.T
 
             # Error quaternion from 2x Gibbs vector
-            da = dx[6:9]
+            da = self._dx[6:9]
             dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
 
             # Reset
-            pos_ins = pos_ins + dx[0:3]
-            vel_ins = vel_ins + dx[3:6]
+            pos_ins = pos_ins + self._dx[0:3]
+            vel_ins = vel_ins + self._dx[3:6]
             q_ins_nm = _quaternion_product(q_ins_nm, dq)
             q_ins_nm = _normalize(q_ins_nm)
             # bias_acc_ins = bias_acc_ins + dx[9:12]

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -896,13 +896,12 @@ class AidedINS(INSMixin):
         # Update (total) state estimate
         da = self._dx[6:9]
         dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
-        pos = self._ins._pos + self._dx[0:3]
-        vel = self._ins._vel + self._dx[3:6]
-        q_nm = _quaternion_product(self._ins._q_nm, dq)
-        q_nm = _normalize(q_nm)
-        b_acc = self._ins._bias_acc + self._dx[9:12]
-        b_gyro = self._ins._bias_gyro + self._dx[12:15]
-        self._x = np.r_[pos, vel, q_nm, b_acc, b_gyro]
+        self._x[0:3] = self._ins._pos + self._dx[0:3]
+        self._x[3:6] = self._ins._vel + self._dx[3:6]
+        self._x[6:10] = _quaternion_product(self._ins._q_nm, dq)
+        self._x[6:10] = _normalize(self._x[6:10])
+        self._x[10:13] = self._ins._bias_acc + self._dx[9:12]
+        self._x[13:16] = self._ins._bias_gyro + self._dx[12:15]
 
         # Project ahead
         self._ins.update(f_imu, w_imu, degrees=False)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -571,11 +571,11 @@ class AidedINS(INSMixin):
         # Strapdown algorithm
         self._ins = StrapdownINS(self._fs, self._x, lat=lat)
 
-        # Error-state
-        self._dx = np.zeros(15)
+        # # Error-state
+        self._dx = np.empty(15)
 
         # Initialize Kalman filter
-        self._dx_prior = self._dx.copy()
+        self._dx_prior = np.zeros(15)
         self._P_prior = np.asarray_chkfinite(P0_prior).reshape(15, 15).copy()
         self._P = np.empty_like(self._P_prior)
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -571,7 +571,7 @@ class AidedINS(INSMixin):
         self._x = np.asarray_chkfinite(x0).reshape(16).copy()
 
         # Error-state
-        self._dx = np.empty(15)
+        self._dx = np.zeros(15)
 
         # Strapdown algorithm
         self._ins = StrapdownINS(self._fs, self._x, lat=lat)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -894,8 +894,21 @@ class AidedINS(INSMixin):
         Q = self._dt * self._G @ self._W @ self._G.T  # process noise covariance matrix
 
         # Update state estimate
-        self._x = self._ins.x
-        self._x[10:] += self._dx[9:]
+        dp = self._dx[:3]
+        dv = self._dx[3:6]
+        da = self._dx[6:9]
+        dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
+        dba = self._dx[9:12]
+        dbg = self._dx[12:15]
+        p = pos_ins + dp
+        v = vel_ins + dv
+        q = _quaternion_product(q_ins_nm, dq)
+        q = _normalize(q)
+        b_acc = bias_acc_ins + dba
+        b_gyro = bias_gyro_ins + dbg
+        x = np.r_[p, v, q, b_acc, b_gyro]
+        self._x = x
+        # self._x[10:] += self._dx[9:]
 
         # Project ahead
         self._ins.update(f_imu, w_imu, degrees=False)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -888,7 +888,7 @@ class AidedINS(INSMixin):
             if head_degrees:
                 head = (np.pi / 180.0) * head
             delta_head = _signed_smallest_angle(
-                head - _h_head(_gibbs_scaled(q_nm_ins)), degrees=False
+                head - _h_head(_gibbs_scaled(q_ins_nm)), degrees=False
             )
 
             if var_head is not None:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -800,10 +800,6 @@ class AidedINS(INSMixin):
             Variance of gravitational reference vector measurement noise in m^2.
         var_head : float, optional
             Variance of heading measurement noise in rad^2.
-        reset_bias_acc : bool, default True
-            Specifies whether to reset the accelerometer bias after the update. I.e.,
-            the estimated error-state bias is incorporated into the INS bias, and
-            consequently the error-state bias is reset to zero.
 
         Returns
         -------

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -822,7 +822,7 @@ class AidedINS(INSMixin):
         bias_acc_ins = self._ins._bias_acc
         bias_gyro_ins = self._ins._bias_gyro
 
-        R_nm_ins = _rot_matrix_from_quaternion(q_nm_ins)  # body-to-ned rotation matrix
+        R_ins_nm = _rot_matrix_from_quaternion(q_ins_nm)  # body-to-ned rotation matrix
 
         # Bias compensated IMU measurements
         f_ins = f_imu - bias_acc_ins

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -870,7 +870,7 @@ class AidedINS(INSMixin):
         if g_ref:
             vg_ref_n = np.array([0.0, 0.0, 1.0])
             vg_meas_m = -_normalize(f_imu - self._bias_acc)
-            delta_g = vg_meas_m - R_nm_ins.T @ vg_ref_n
+            delta_g = vg_meas_m - R_ins_nm.T @ vg_ref_n
 
             if var_g is not None:
                 var_g = np.asarray_chkfinite(var_g, dtype=float).reshape(3).copy()

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -829,9 +829,9 @@ class AidedINS(INSMixin):
         w_ins = w_imu - bias_gyro_ins
 
         # Update system matrices
-        self._update_F(q_nm_ins, f_ins, w_ins)
-        self._update_G(q_nm_ins)
-        self._update_H(q_nm_ins)
+        self._update_F(q_ins_nm, f_ins, w_ins)
+        self._update_G(q_ins_nm)
+        self._update_H(q_ins_nm)
 
         # Position aiding
         dz_temp, var_z_temp, H_temp = [], [], []

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -518,13 +518,15 @@ class AidedINS(INSMixin):
         Latitude used to calculate the gravitational acceleration. If none
         provided, the 'standard gravity' is assumed.
     reset_bias_acc : bool, default True
-        Specifies whether to reset the accelerometer bias to zero after each update cycle.
-        I.e., the estimated error-state bias is incorporated into the strapdown INS'
-        bias, effectively resetting the error-state bias to zero. Defaults to ``True``.
+        Specifies whether to reset the accelerometer bias after each update cycle. If
+        set to ``True``, the estimated error-state bias is incorporated into the
+        strapdown algorithm's bias state, effectively resetting the error-state bias to
+        zero. Defaults to ``True``.
     reset_bias_gyro : bool, default True
-        Specifies whether to reset the gyroscope bias to zero after each update cycle.
-        I.e., the estimated error-state bias is incorporated into the strapdown INS'
-        bias, effectively resetting the error-state bias to zero. Defaults to ``True``.
+        Specifies whether to reset the gyroscope bias after each update cycle. If set to
+        ``True``, the estimated error-state bias is incorporated into the strapdown
+        algorithm's bias state, effectively resetting the error-state bias to zero.
+        Defaults to ``True``.
     """
 
     _I15 = np.eye(15)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -575,7 +575,10 @@ class AidedINS(INSMixin):
         self._W = self._prep_W(err_acc, err_gyro)
 
     def _combine_states(self, x_ins, dx):
-        """Combine INS states with error-state estimates."""
+        """
+        Combine the INS state with the error-state estimate to form the total state
+        estimate.
+        """
         da = dx[6:9]
         dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
         pos = x_ins[0:3] + dx[0:3]

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -818,7 +818,7 @@ class AidedINS(INSMixin):
         # Current INS state estimates
         pos_ins = self._ins._pos
         vel_ins = self._ins._vel
-        q_nm_ins = self._ins._q_nm
+        q_ins_nm = self._ins._q_nm
         bias_acc_ins = self._ins._bias_acc
         bias_gyro_ins = self._ins._bias_gyro
 

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -570,11 +570,11 @@ class AidedINS(INSMixin):
         # Total state
         self._x = np.asarray_chkfinite(x0).reshape(16).copy()
 
-        # Strapdown algorithm
-        self._ins = StrapdownINS(self._fs, self._x, lat=lat)
-
         # Error-state
         self._dx = np.empty(15)
+
+        # Strapdown algorithm
+        self._ins = StrapdownINS(self._fs, self._x, lat=lat)
 
         # Initialize Kalman filter
         self._dx_prior = np.zeros(15)

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -573,7 +573,7 @@ class AidedINS(INSMixin):
         # Strapdown algorithm
         self._ins = StrapdownINS(self._fs, self._x, lat=lat)
 
-        # # Error-state
+        # Error-state
         self._dx = np.empty(15)
 
         # Initialize Kalman filter

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -568,7 +568,7 @@ class AidedINS(INSMixin):
         # Total state
         self._x = np.asarray_chkfinite(x0).reshape(16).copy()
 
-        # Strapdown algorithm / INS state
+        # Strapdown algorithm
         self._ins = StrapdownINS(self._fs, self._x, lat=lat)
 
         # Error-state

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -822,7 +822,7 @@ class AidedINS(INSMixin):
         # Gravity reference vector aiding
         if g_ref:
             vg_ref_n = np.array([0.0, 0.0, 1.0])
-            vg_meas_m = -_normalize(f_ins - self._dx[9:12])
+            vg_meas_m = -_normalize(f_imu - self._bias_acc)
             delta_g = vg_meas_m - R_ins_nm.T @ vg_ref_n
 
             if var_g is not None:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -816,9 +816,6 @@ class AidedINS(INSMixin):
         if degrees:
             w_imu = (np.pi / 180.0) * w_imu
 
-        # Update current state estimate
-        # self._x = self._ins.x
-
         # Current INS state estimates
         pos_ins = self._ins._pos
         vel_ins = self._ins._vel

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -586,7 +586,8 @@ class AidedINS(INSMixin):
         self._H = self._prep_H(q0)
         self._W = self._prep_W(err_acc, err_gyro)
 
-    def _combine_states(self, x_ins, dx):
+    @staticmethod
+    def _combine_states(x_ins, dx):
         """
         Combine the INS state with the error-state estimate to form the total state
         estimate.

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -864,7 +864,7 @@ class AidedINS(INSMixin):
             K = self._P_prior @ H.T @ inv(H @ self._P_prior @ H.T + R)
 
             # Update error-state estimate with measurement
-            dx = self._dx + K @ dz
+            dx = self._dx_prior + K @ dz
 
             # Compute error covariance for updated estimate
             self._P = (self._I15 - K @ H) @ self._P_prior @ (

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -618,6 +618,8 @@ class Test_AidedINS:
             err_acc,
             err_gyro,
             lat=60.0,
+            reset_bias_acc=False,
+            reset_bias_gyro=True,
         )
 
         assert isinstance(ains, AidedINS)
@@ -626,10 +628,16 @@ class Test_AidedINS:
         assert ains._dt == 1.0 / 10.24
         assert ains._err_acc == err_acc
         assert ains._err_gyro == err_gyro
+        assert ains._reset_bias_acc is False
+        assert ains._reset_bias_gyro is True
         assert isinstance(ains._ins, StrapdownINS)
 
         np.testing.assert_array_almost_equal(ains._x, x0)
+        np.testing.assert_array_almost_equal(ains._ins._x, x0)
+        np.testing.assert_array_almost_equal(ains._dx, np.zeros(15))
+        np.testing.assert_array_almost_equal(ains._dx_prior, np.zeros(15))
         np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)
+
         assert ains._P.shape == (15, 15)
 
         # Check default aidning variances is None

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1490,11 +1490,6 @@ class Test_AidedINS:
         np.testing.assert_array_almost_equal(ains_b.x, x)
         np.testing.assert_array_almost_equal(ains_a._ins.x[10:], x[10:])  # with reset
         np.testing.assert_array_almost_equal(ains_b._ins.x[10:], x0[10:])  # no reset
-        # np.testing.assert_array_almost_equal(ains_a._dx, np.zeros(15))
-        # np.testing.assert_array_almost_equal(ains_b._x_ins[:10], x[:10])
-        # np.testing.assert_array_almost_equal(ains_b._x_ins[10:], x0[10:])
-        # np.testing.assert_array_almost_equal(ains_b._dx[:9], np.zeros(9))
-        # np.testing.assert_array_almost_equal(ains_b._dx[9:], x[10:] - x0[10:])
 
     @pytest.mark.parametrize(
         "benchmark_gen",

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -628,7 +628,6 @@ class Test_AidedINS:
         assert ains._err_gyro == err_gyro
         assert isinstance(ains._ins, StrapdownINS)
 
-        np.testing.assert_array_almost_equal(ains._x0, x0)
         np.testing.assert_array_almost_equal(ains._x, x0)
         np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)
         np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -629,7 +629,6 @@ class Test_AidedINS:
         assert isinstance(ains._ins, StrapdownINS)
 
         np.testing.assert_array_almost_equal(ains._x, x0)
-        np.testing.assert_array_almost_equal(ains._P0_prior, P0_prior)
         np.testing.assert_array_almost_equal(ains._P_prior, P0_prior)
         assert ains._P.shape == (15, 15)
 

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1457,8 +1457,8 @@ class Test_AidedINS:
             var_vel,
             var_g,
             var_head,
-            reset_bias_acc=True,  # reset bias
-            reset_bias_gyro=True,  # reset bias
+            reset_bias_acc=True,  # with reset
+            reset_bias_gyro=True,  # with reset
         )
 
         ains_b = AidedINS(
@@ -1488,8 +1488,8 @@ class Test_AidedINS:
         x = ains_a.x
         np.testing.assert_array_almost_equal(ains_a.x, x)
         np.testing.assert_array_almost_equal(ains_b.x, x)
-        np.testing.assert_array_almost_equal(ains_a._ins.x[10:], x[10:])
-        np.testing.assert_array_almost_equal(ains_b._ins.x[10:], x0[10:])
+        np.testing.assert_array_almost_equal(ains_a._ins.x[10:], x[10:])  # with reset
+        np.testing.assert_array_almost_equal(ains_b._ins.x[10:], x0[10:])  # no reset
         # np.testing.assert_array_almost_equal(ains_a._dx, np.zeros(15))
         # np.testing.assert_array_almost_equal(ains_b._x_ins[:10], x[:10])
         # np.testing.assert_array_almost_equal(ains_b._x_ins[10:], x0[10:])

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1037,9 +1037,83 @@ class Test_AidedINS:
         x_ins_out = ains._ins._x
         dx_out = ains._dx
 
-        np.testing.assert_array_almost_equal(x_out, x_tot)
-        np.testing.assert_array_almost_equal(x_ins_out, x_tot)
-        np.testing.assert_array_almost_equal(dx_out, np.zeros(15))
+        x_expect = x_tot
+        x_ins_expect = x_tot
+        dx_expect = np.zeros(15)
+
+        np.testing.assert_array_almost_equal(x_out, x_expect)
+        np.testing.assert_array_almost_equal(x_ins_out, x_ins_expect)
+        np.testing.assert_array_almost_equal(dx_out, dx_expect)
+
+    def test__reset_not_bias(self, ains):
+        x_ins = np.array(
+            [
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                5.0,
+                6.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.5,
+            ]
+        )
+        dx = np.array(
+            [
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.6,
+                0.05,
+                0.06,
+                0.07,
+                0.7,
+                0.8,
+                0.9,
+                0.10,
+                0.11,
+                0.12,
+            ]
+        )
+
+        da = dx[6:9]
+        dq = (1.0 / np.sqrt(4.0 + da.T @ da)) * np.r_[2.0, da]
+
+        x_tot = np.r_[
+            x_ins[0:6] + dx[0:6],
+            _normalize(_quaternion_product(x_ins[6:10], dq)),
+            x_ins[10:13] + dx[9:12],
+            x_ins[13:16] + dx[12:15],
+        ]
+
+        ains._x = x_tot
+        ains._ins._x = x_ins
+        ains._dx = dx
+        ains._reset_bias_acc = False
+        ains._reset_bias_gyro = False
+        ains._reset()
+
+        x_out = ains._x
+        x_ins_out = ains._ins._x
+        dx_out = ains._dx
+
+        x_expect = x_tot
+        x_ins_expect = np.r_[x_tot[:10], x_ins[10:]]
+        dx_expect = np.r_[np.zeros(9), dx[9:]]
+
+        np.testing.assert_array_almost_equal(x_out, x_expect)
+        np.testing.assert_array_almost_equal(x_ins_out, x_ins_expect)
+        np.testing.assert_array_almost_equal(dx_out, dx_expect)
 
     def test_update_return_self(self, ains):
         g = gravity()

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -1595,6 +1595,8 @@ class Test_AidedINS:
             var_vel=np.ones_like(var_vel) * 1e9,  # correct values given in update
             var_g=var_g,
             var_head=None,  # provided during update
+            reset_bias_acc=False,
+            reset_bias_gyro=True,
         )
 
         # Apply filter


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
Make resetting of bias terms optional by introducing two boolean flags, `reset_bias_acc` and `reset_bias_gyro`.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
