### PR TITLE
Add function to decompose calibration matrix into pure rotation and scale

### DIFF
--- a/src/smsfusion/calibrate/__init__.py
+++ b/src/smsfusion/calibrate/__init__.py
@@ -1,3 +1,3 @@
-from ._calibrate import calibrate
+from ._calibrate import calibrate, decompose
 
-__all__ = ["calibrate"]
+__all__ = ["calibrate", "decompose"]

--- a/src/smsfusion/calibrate/_calibrate.py
+++ b/src/smsfusion/calibrate/_calibrate.py
@@ -3,7 +3,7 @@ from numpy.typing import ArrayLike, NDArray
 
 
 def calibrate(
-    xyz_ref: ArrayLike, xyz: ArrayLike
+    xyz_ref: ArrayLike, xyz: ArrayLike, bias_pre: bool = False
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """
     Calculate the calibration values for 3-axis sensors.
@@ -14,7 +14,9 @@ def calibrate(
         Reference values for the 3-axis sensors.
     xyz : array-like, shape (N, 3)
         Measured values from the 3-axis sensors.
-
+    bias_pre : bool, default False
+        If set to ``True``, the alternative calibration model where biases are added
+        first is assumed. See Notes.
 
     Notes
     -----
@@ -22,9 +24,14 @@ def calibrate(
 
         xyz_ref = W @ xyz + bias
 
+    The alternative calibration model where biases are added first is defined as::
+
+        xyz_ref = W @ (xyz + bias)
+
+    The alternative model is enabled by setting ``bias_pre=True``.
+
     In total, 12 calibration parameters are needed. Accordingly, at least 4
     measurements (of 3 data points) are required to calibrate.
-
 
     Returns
     -------
@@ -48,4 +55,7 @@ def calibrate(
 
     W = x[:3, :].T
     bias = x[3, :]
+
+    if bias_pre:
+        bias = np.linalg.inv(W) @ bias
     return W, bias

--- a/src/smsfusion/calibrate/_calibrate.py
+++ b/src/smsfusion/calibrate/_calibrate.py
@@ -39,6 +39,7 @@ def calibrate(
         Calibration matrix for the 3-axis sensors.
     bias : numpy.ndarray, shape (3,)
         Bias values for the 3-axis sensors.
+
     """
     xyz_ref = np.asarray_chkfinite(xyz_ref)
     xyz = np.asarray_chkfinite(xyz)

--- a/src/smsfusion/calibrate/_calibrate.py
+++ b/src/smsfusion/calibrate/_calibrate.py
@@ -39,8 +39,8 @@ def calibrate(
         Calibration matrix for the 3-axis sensors.
     bias : numpy.ndarray, shape (3,)
         Bias values for the 3-axis sensors.
-
     """
+
     xyz_ref = np.asarray_chkfinite(xyz_ref)
     xyz = np.asarray_chkfinite(xyz)
 

--- a/src/smsfusion/calibrate/_calibrate.py
+++ b/src/smsfusion/calibrate/_calibrate.py
@@ -59,3 +59,40 @@ def calibrate(
     if bias_pre:
         bias = np.linalg.inv(W) @ bias
     return W, bias
+
+
+def decompose(
+    W: ArrayLike,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """
+    Polar decompose the calibration matrix into pure rotation and scaling.
+
+    The polar decomposition is defined as::
+
+        W = R @ S
+
+    where ``R`` is pure rotation and ``S`` is scaling.
+
+    Parameters
+    ----------
+    W : array-like, shape (3, 3)
+        Calibration matrix.
+
+    Returns
+    -------
+    R : numpy.ndarray, shape (3, 3)
+        Pure rotation associated with the calibration matrix.
+    S : numpy.ndarray, shape (3, 3)
+        Scaling associated with the calibration matrix.
+    """
+
+    W = np.asarray_chkfinite(W)
+
+    if W.shape != (3, 3):
+        raise ValueError("Invalid shape. W must have shape (3, 3).")
+
+    # Copied from scipy.linalg.polar
+    w, s, vh = np.linalg.svd(W, full_matrices=False)
+    R = w.dot(vh)
+    S = (vh.T.conj() * s).dot(vh)
+    return R, S

--- a/src/smsfusion/calibrate/_calibrate.py
+++ b/src/smsfusion/calibrate/_calibrate.py
@@ -3,7 +3,7 @@ from numpy.typing import ArrayLike, NDArray
 
 
 def calibrate(
-    xyz_ref: ArrayLike, xyz: ArrayLike, bias_pre: bool = False
+    xyz_ref: ArrayLike, xyz: ArrayLike, bias_alt: bool = False
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """
     Calculate the calibration values for 3-axis sensors.
@@ -14,9 +14,9 @@ def calibrate(
         Reference values for the 3-axis sensors.
     xyz : array-like, shape (N, 3)
         Measured values from the 3-axis sensors.
-    bias_pre : bool, default False
-        If set to ``True``, the alternative calibration model where biases are added
-        first is assumed. See Notes.
+    bias_alt : bool, default False
+        If set to ``True``, the bias definition of the alternative calibration model
+        is returned. See Notes.
 
     Notes
     -----
@@ -28,7 +28,7 @@ def calibrate(
 
         xyz_ref = W @ (xyz + bias)
 
-    The alternative model is enabled by setting ``bias_pre=True``.
+    The alternative model is enabled by setting ``bias_alt=True``.
 
     In total, 12 calibration parameters are needed. Accordingly, at least 4
     measurements (of 3 data points) are required to calibrate.
@@ -57,7 +57,7 @@ def calibrate(
     W = x[:3, :].T
     bias = x[3, :]
 
-    if bias_pre:
+    if bias_alt:
         bias = np.linalg.inv(W) @ bias
     return W, bias
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -35,6 +35,32 @@ class Test_calibrate:
     @pytest.mark.parametrize(
         "xyz_ref",
         [
+            np.random.default_rng().random(size=(4, 3)),
+            np.random.default_rng().random(size=(40, 3)),
+        ],
+    )
+    def test_exact_alternate(self, xyz_ref):
+        xyz_ref = xyz_ref / np.sqrt(np.sum(xyz_ref**2, axis=1))[:, np.newaxis]
+
+        # Some typical calibration values
+        W_expected = np.array(
+            [
+                [0.99304605, -0.00175537, -0.00554466],
+                [0.00111272, 1.00574815, -0.01341676],
+                [-0.00113683, 0.01124392, 0.983339],
+            ]
+        )
+        bias_expected = np.array([-0.03336607, 0.00441664, -0.00619647])
+
+        xyz = (np.linalg.inv(W_expected) @ (xyz_ref - bias_expected).T).T
+
+        W_out, bias_alt_out = calibrate(xyz_ref, xyz, bias_pre=True)
+        np.testing.assert_almost_equal(W_expected, W_out)
+        np.testing.assert_almost_equal(bias_expected, W_out @ bias_alt_out)
+
+    @pytest.mark.parametrize(
+        "xyz_ref",
+        [
             np.random.default_rng().random(size=(400, 3)),
             np.random.default_rng().random(size=(4000, 3)),
         ],

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from smsfusion.calibrate import calibrate
+from smsfusion.calibrate import calibrate, decompose
 
 
 class Test_calibrate:
@@ -126,3 +126,37 @@ class Test_calibrate:
         xyz = np.ones_like(xyz_ref)[:-1]
         with pytest.raises(ValueError):
             _ = calibrate(xyz_ref, xyz)
+
+
+class Test_decompose:
+    def test_decompose(self):
+
+        # Some typical calibration values
+        W_expected = np.array(
+            [
+                [0.99304605, -0.00175537, -0.00554466],
+                [0.00111272, 1.00574815, -0.01341676],
+                [-0.00113683, 0.01124392, 0.983339],
+            ]
+        )
+
+        R, S = decompose(W_expected)
+        W_out = R @ S
+
+        assert R.shape == S.shape
+        assert R.shape == (3, 3)
+        np.testing.assert_almost_equal(W_expected, W_out)
+
+    def test_wrong_shape(self):
+
+        # Some typical calibration values
+        W_expected = np.array(
+            [
+                [0.99304605, -0.00175537],
+                [0.00111272, 1.00574815],
+                [-0.00113683, 0.01124392],
+            ]
+        )
+
+        with pytest.raises(ValueError):
+            _ = decompose(W_expected)

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -54,7 +54,7 @@ class Test_calibrate:
 
         xyz = (np.linalg.inv(W_expected) @ (xyz_ref - bias_expected).T).T
 
-        W_out, bias_alt_out = calibrate(xyz_ref, xyz, bias_pre=True)
+        W_out, bias_alt_out = calibrate(xyz_ref, xyz, bias_alt=True)
         np.testing.assert_almost_equal(W_expected, W_out)
         np.testing.assert_almost_equal(bias_expected, W_out @ bias_alt_out)
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.spatial.transform import Rotation
 
 from smsfusion.calibrate import calibrate, decompose
 
@@ -146,6 +147,25 @@ class Test_decompose:
         assert R.shape == S.shape
         assert R.shape == (3, 3)
         np.testing.assert_almost_equal(W_expected, W_out)
+
+    @pytest.mark.parametrize(
+        "R, S",
+        [
+            (
+                Rotation.from_euler(
+                    "ZYX", (2.0 * np.pi * np.random.default_rng().random(size=3))
+                ).as_matrix(),
+                np.diag(np.random.default_rng().random(size=3)),
+            )
+            for _ in range(10)
+        ],
+    )
+    def test_decompose_inverse(self, R, S):
+        W = R @ S
+
+        R_out, S_out = decompose(W)
+        np.testing.assert_almost_equal(R, R_out)
+        np.testing.assert_almost_equal(S, S_out)
 
     def test_wrong_shape(self):
 


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
See smsfusion.calibrate.decompose

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
