### PR TITLE
Add scipy to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "numba",
-  "numpy"
+  "numpy",
+  "scipy"  # required by numba
 ]
 
 [project.urls]


### PR DESCRIPTION
Numba requires scipy to do linear algebra without declaring it in the dependencies. Thus, adding scipy to the smsfusion dependencies.

### This PR is related to user story DLAB-

## Description
Provide a short description about the work that has been done.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below).
- [ ] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
