### PR TITLE
Set g value instead of latitude for AidenINS and StrapdownINS

### DIFF
--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -387,9 +387,8 @@ class StrapdownINS(INSMixin):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    lat : float, optional
-        Latitude used to calculate the gravitational acceleration. If none
-        provided, the 'standard gravity' is assumed.
+    g_ref : float, default 9.80665
+        The gravitational acceleration. Default is 'standard gravity' of 9.80665.
 
     Notes
     -----
@@ -397,14 +396,14 @@ class StrapdownINS(INSMixin):
     ensure unity.
     """
 
-    def __init__(self, fs: float, x0: ArrayLike, lat: float | None = None) -> None:
+    def __init__(self, fs: float, x0: ArrayLike, g_ref: float = 9.80665) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
 
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()
-        self._g = np.array([0, 0, gravity(lat)])  # gravity vector in NED
+        self._g = np.array([0, 0, g_ref])  # gravity vector in NED
 
     def reset(self, x_new: ArrayLike) -> None:
         """
@@ -610,9 +609,8 @@ class AidedINS(INSMixin):
         to the IMU expressed in the IMU's measurement frame. For instance, the location
         of the GNSS antenna relative to the IMU. By default it is assumed that the
         aiding position coincides with the IMU's origin.
-    lat : float, optional
-        Latitude used to calculate the gravitational acceleration. If ``None`` provided,
-        the 'standard gravity' of 9.80665 is assumed.
+    g_ref : float, default 9.80665
+        The gravitational acceleration. Default is 'standard gravity' of 9.80665.
     ignore_bias_acc : bool, default True
         Determines whether the accelerometer bias should be included in the error estimate.
         If set to ``True``, the accelerometer bias provided in ``x0`` during initialization
@@ -647,20 +645,20 @@ class AidedINS(INSMixin):
         err_acc: dict[str, float],
         err_gyro: dict[str, float],
         lever_arm: ArrayLike = np.zeros(3),
-        lat: float | None = None,
+        g_ref: float = 9.80665,
         ignore_bias_acc: bool = True,
     ) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
         self._err_acc = err_acc
         self._err_gyro = err_gyro
-        self._lat = lat
+        self._g_ref = g_ref
         self._lever_arm = np.asarray_chkfinite(lever_arm).reshape(3).copy()
         self._ignore_bias_acc = ignore_bias_acc
         self._dq_prealloc = np.array([2.0, 0.0, 0.0, 0.0])  # Preallocation
 
         # Strapdown algorithm / INS state
-        self._ins = StrapdownINS(self._fs, x0_prior, lat=self._lat)
+        self._ins = StrapdownINS(self._fs, x0_prior, g_ref=self._g_ref)
 
         # Total state
         self._x = self._ins.x

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -387,7 +387,7 @@ class StrapdownINS(INSMixin):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    g_ref : float, default 9.80665
+    g : float, default 9.80665
         The gravitational acceleration. Default is 'standard gravity' of 9.80665.
 
     Notes
@@ -396,14 +396,14 @@ class StrapdownINS(INSMixin):
     ensure unity.
     """
 
-    def __init__(self, fs: float, x0: ArrayLike, g_ref: float = 9.80665) -> None:
+    def __init__(self, fs: float, x0: ArrayLike, g: float = 9.80665) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
 
         self._x0 = np.asarray_chkfinite(x0).reshape(16).copy()
         self._x0[6:10] = _normalize(self._x0[6:10])
         self._x = self._x0.copy()
-        self._g = np.array([0, 0, g_ref])  # gravity vector in NED
+        self._g = np.array([0, 0, g])  # gravity vector in NED
 
     def reset(self, x_new: ArrayLike) -> None:
         """
@@ -609,7 +609,7 @@ class AidedINS(INSMixin):
         to the IMU expressed in the IMU's measurement frame. For instance, the location
         of the GNSS antenna relative to the IMU. By default it is assumed that the
         aiding position coincides with the IMU's origin.
-    g_ref : float, default 9.80665
+    g : float, default 9.80665
         The gravitational acceleration. Default is 'standard gravity' of 9.80665.
     ignore_bias_acc : bool, default True
         Determines whether the accelerometer bias should be included in the error estimate.
@@ -645,20 +645,20 @@ class AidedINS(INSMixin):
         err_acc: dict[str, float],
         err_gyro: dict[str, float],
         lever_arm: ArrayLike = np.zeros(3),
-        g_ref: float = 9.80665,
+        g: float = 9.80665,
         ignore_bias_acc: bool = True,
     ) -> None:
         self._fs = fs
         self._dt = 1.0 / fs
         self._err_acc = err_acc
         self._err_gyro = err_gyro
-        self._g_ref = g_ref
+        self._g = g
         self._lever_arm = np.asarray_chkfinite(lever_arm).reshape(3).copy()
         self._ignore_bias_acc = ignore_bias_acc
         self._dq_prealloc = np.array([2.0, 0.0, 0.0, 0.0])  # Preallocation
 
         # Strapdown algorithm / INS state
-        self._ins = StrapdownINS(self._fs, x0_prior, g_ref=self._g_ref)
+        self._ins = StrapdownINS(self._fs, x0_prior, g=self._g)
 
         # Total state
         self._x = self._ins.x
@@ -726,7 +726,7 @@ class AidedINS(INSMixin):
             "err_acc": self._err_acc,
             "err_gyro": self._err_gyro,
             "lever_arm": self._lever_arm.tolist(),
-            "lat": self._lat,
+            "g": self._g,
             "ignore_bias_acc": self._ignore_bias_acc,
         }
         return params

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -654,7 +654,7 @@ class Test_AidedINS:
             err_acc,
             err_gyro,
             lever_arm=(1, 2, 3),
-            lat=60.0,
+            g=9.81,
             ignore_bias_acc=False,
         )
 
@@ -675,7 +675,7 @@ class Test_AidedINS:
         assert ains._P.shape == (15, 15)
 
         # Check that correct latitude (and thus gravity) is used
-        g_expect = np.array([0.0, 0.0, gravity(60.0)])
+        g_expect = np.array([0.0, 0.0, 9.81])
         np.testing.assert_array_almost_equal(ains._ins._g, g_expect)
 
         assert ains._F.shape == (15, 15)
@@ -709,7 +709,7 @@ class Test_AidedINS:
             err_acc,
             err_gyro,
             lever_arm=(1, 2, 3),
-            lat=60.0,
+            g=9.80665,
             ignore_bias_acc=True,
         )
 
@@ -757,7 +757,7 @@ class Test_AidedINS:
         assert ains_b._err_acc == ains._err_acc
         assert ains_b._err_gyro == ains._err_gyro
         np.testing.assert_array_almost_equal(ains_b._lever_arm, ains._lever_arm)
-        assert ains_b._lat == ains._lat
+        assert ains_b._g == ains._g
         np.testing.assert_array_almost_equal(ains_b._ins._x, ains._ins._x)
         np.testing.assert_array_almost_equal(ains_b._P_prior, ains._P_prior)
         np.testing.assert_array_almost_equal(


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
Replace input parameter `lat` in `AidedINS` and `StrapdownINS` with `g_ref`. This allows the user manually control and set the appropriate value. The old behavior can still be used by setting `g_ref = gravity(lat)`

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
