### PR TITLE
Add default P0 and noise parameters to INS classes

### DIFF
--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -129,15 +129,8 @@ velocity and attitude (PVA) of a moving body using the :func:`~smsfusion.AidedIN
     bg0 = np.zeros(3)  # gyroscope bias [rad/s]
     x0 = np.concatenate((p0, v0, q0, ba0, bg0))
 
-    # Initial (a priori) error covariance matrix
-    P0 = np.eye(12) * 1e-3
-
-    # IMU noise characteristics
-    err_acc = sf.constants.ERR_ACC_MOTION2  # m/s^2
-    err_gyro = sf.constants.ERR_GYRO_MOTION2  # rad/s
-
     # Initialize AINS
-    ains = sf.AidedINS(fs, x0, P0, err_acc, err_gyro)
+    ains = sf.AidedINS(fs, x0)
 
     # Estimate PVA states sequentially using AINS
     pos_est, vel_est, euler_est = [], [], []
@@ -189,15 +182,8 @@ the :func:`~smsfusion.AHRS` class:
     bg0 = np.zeros(3)  # gyroscope bias [rad/s]
     x0 = np.concatenate((p0, v0, q0, ba0, bg0))
 
-    # Initial (a priori) error covariance matrix
-    P0 = np.eye(12) * 1e-3
-
-    # IMU noise characteristics
-    err_acc = sf.constants.ERR_ACC_MOTION2  # m/s^2
-    err_gyro = sf.constants.ERR_GYRO_MOTION2  # rad/s
-
     # Initialize AHRS
-    ahrs = sf.AHRS(fs, x0, P0, err_acc, err_gyro)
+    ahrs = sf.AHRS(fs, x0)
 
     # Estimate attitude sequentially using AHRS
     euler_est = []
@@ -246,15 +232,8 @@ estimate the roll and pitch degrees of freedom of a moving body using the
     bg0 = np.zeros(3)  # gyroscope bias [rad/s]
     x0 = np.concatenate((p0, v0, q0, ba0, bg0))
 
-    # Initial (a priori) error covariance matrix
-    P0 = np.eye(12) * 1e-3
-
-    # IMU noise characteristics
-    err_acc = sf.constants.ERR_ACC_MOTION2  # m/s^2
-    err_gyro = sf.constants.ERR_GYRO_MOTION2  # rad/s
-
     # Initialize VRU
-    vru = sf.VRU(fs, x0, P0, err_acc, err_gyro)
+    vru = sf.VRU(fs, x0)
 
     # Estimate roll and pitch sequentially using VRU
     roll_pitch_est = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ complete = [
 dependencies = [
   "sphinx",
   "myst-parser",
-  "snowballstemmer<3.0.0"
 ]
 
 [tool.hatch.envs.docs.scripts]

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -6,7 +6,7 @@ import numpy as np
 from numba import njit
 from numpy.typing import ArrayLike, NDArray
 
-from smsfusion.constants import DEFAULT_P0_VALUE, ERR_ACC_MOTION2, ERR_GYRO_MOTION2
+from smsfusion.constants import ERR_ACC_MOTION2, ERR_GYRO_MOTION2, P0
 
 from ._transforms import (
     _angular_matrix_from_quaternion,
@@ -603,7 +603,7 @@ class AidedINS(INSMixin):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0_prior : array-like (shape (12, 12) or (15, 15)), default np.eye(12) * :const:`smsfusion.constants.DEFAULT_P0_VALUE`
+    P0_prior : array-like (shape (12, 12) or (15, 15)), default np.eye(12) * 1e-6 (:const:`smsfusion.constants.P0`)
         Initial (a priori) estimate of the error covariance matrix, **P**. If not given, a
         small diagonal matrix will be used. If the accelerometer bias is excluded from the
         error estimate (see ``ignore_bias_acc``), the covariance matrix should be of shape
@@ -665,7 +665,7 @@ class AidedINS(INSMixin):
         self,
         fs: float,
         x0_prior: ArrayLike,
-        P0_prior: ArrayLike = np.eye(12) * DEFAULT_P0_VALUE,
+        P0_prior: ArrayLike = P0,
         err_acc: dict[str, float] = ERR_ACC_MOTION2,
         err_gyro: dict[str, float] = ERR_GYRO_MOTION2,
         g: float = 9.80665,
@@ -1130,7 +1130,7 @@ class VRU(AidedINS):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0_prior : array-like, shape (12, 12), default np.eye(12) * :const:`smsfusion.constants.DEFAULT_P0_VALUE`
+    P0_prior : array-like, shape (12, 12), default np.eye(12) * 1e-6 (:const:`smsfusion.constants.P0`)
         Initial (a priori) estimate of the error covariance matrix, **P**.
     err_acc : dict of {str: float}, default :const:`smsfusion.constants.ERR_ACC_MOTION2`
         Dictionary containing accelerometer noise parameters with keys:
@@ -1163,7 +1163,7 @@ class VRU(AidedINS):
         self,
         fs: float,
         x0_prior: ArrayLike,
-        P0_prior: ArrayLike = np.eye(12) * DEFAULT_P0_VALUE,
+        P0_prior: ArrayLike = P0,
         err_acc: dict[str, float] = ERR_ACC_MOTION2,
         err_gyro: dict[str, float] = ERR_GYRO_MOTION2,
         g: float = 9.80665,
@@ -1262,7 +1262,7 @@ class AHRS(AidedINS):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0_prior : array-like, shape (12, 12), default np.eye(12) * :const:`smsfusion.constants.DEFAULT_P0_VALUE`
+    P0_prior : array-like, shape (12, 12), default np.eye(12) * 1e-6 (:const:`smsfusion.constants.P0`)
         Initial (a priori) estimate of the error covariance matrix, **P**.
     err_acc : dict of {str: float}, default :const:`smsfusion.constants.ERR_ACC_MOTION2`
         Dictionary containing accelerometer noise parameters with keys:
@@ -1295,7 +1295,7 @@ class AHRS(AidedINS):
         self,
         fs: float,
         x0_prior: ArrayLike,
-        P0_prior: ArrayLike = np.eye(12) * DEFAULT_P0_VALUE,
+        P0_prior: ArrayLike = P0,
         err_acc: dict[str, float] = ERR_ACC_MOTION2,
         err_gyro: dict[str, float] = ERR_GYRO_MOTION2,
         g: float = 9.80665,

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -644,7 +644,7 @@ class AidedINS(INSMixin):
         information or minimal dynamic motion, making bias estimation unreliable. Note
         that this will reduce the error-state dimension from 15 to 12, and hence also the
         error covariance matrix, **P**, from dimension (15, 15) to (12, 12). When set to
-        false, the P0_prior argument must have shape (15, 15).
+        ``False``, the P0_prior argument must have shape (15, 15).
     """
 
     # Permutation matrix for reordering error-state bias terms, such that:

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -605,7 +605,8 @@ class AidedINS(INSMixin):
         * Gyroscope bias in x, y, z directions (3 elements).
     P0_prior : array-like (shape (15, 15) or (12, 12)) or None, default None
         Initial (a priori) estimate of the error covariance matrix, **P**. If not given, a
-        small diagonal matrix (``1e-6 * numpy.eye(15)`` or ``1e-6 * numpy.eye(12)``) will be used.
+        small diagonal matrix (``smsfusion.constants.DEFAULT_P0_VALUE * numpy.eye(15)`` or
+        ``smsfusion.constants.DEFAULT_P0_VALUE * numpy.eye(12)``) will be used.
         If the accelerometer bias is excluded from the error estimate (see ``ignore_bias_acc``),
         the covariance matrix should be of shape (12, 12) instead of (15, 15) to reflect the reduced
         state dimensionality.
@@ -1123,9 +1124,8 @@ class VRU(AidedINS):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0_prior : array-like, shape (12, 12), default np.eye(12) * :const:`DEFAULT_P0_VALUE`
-        Initial (a priori) estimate of the error covariance matrix, **P**. If not given, a
-        small diagonal matrix (``1e-6 * numpy.eye(12)``) will be used.
+    P0_prior : array-like, shape (12, 12), default np.eye(12) * :const:`smsfusion.constants.DEFAULT_P0_VALUE`
+        Initial (a priori) estimate of the error covariance matrix, **P**.
     err_acc : dict of {str: float}, default :const:`smsfusion.constants.ERR_ACC_MOTION2`
         Dictionary containing accelerometer noise parameters with keys:
 
@@ -1252,9 +1252,8 @@ class AHRS(AidedINS):
         * Attitude as unit quaternion (4 elements).
         * Accelerometer bias in x, y, z directions (3 elements).
         * Gyroscope bias in x, y, z directions (3 elements).
-    P0_prior : array-like, shape (12, 12)
-        Initial (a priori) estimate of the error covariance matrix, **P**. If not given, a
-        small diagonal matrix (``1e-6 * numpy.eye(15)``) will be used.
+    P0_prior : array-like, shape (12, 12), default np.eye(12) * :const:`smsfusion.constants.DEFAULT_P0_VALUE`
+        Initial (a priori) estimate of the error covariance matrix, **P**.
     err_acc : dict of {str: float}, default :const:`smsfusion.constants.ERR_ACC_MOTION2`
         Dictionary containing accelerometer noise parameters with keys:
 

--- a/src/smsfusion/constants/__init__.py
+++ b/src/smsfusion/constants/__init__.py
@@ -1,9 +1,9 @@
 from ._constants import (
-    DEFAULT_P0_VALUE,
     ERR_ACC_MOTION1,
     ERR_ACC_MOTION2,
     ERR_GYRO_MOTION1,
     ERR_GYRO_MOTION2,
+    P0,
 )
 
 __all__ = [
@@ -11,5 +11,5 @@ __all__ = [
     "ERR_ACC_MOTION2",
     "ERR_GYRO_MOTION1",
     "ERR_GYRO_MOTION2",
-    "DEFAULT_P0_VALUE",
+    "P0",
 ]

--- a/src/smsfusion/constants/__init__.py
+++ b/src/smsfusion/constants/__init__.py
@@ -1,8 +1,15 @@
 from ._constants import (
+    DEFAULT_P0_VALUE,
     ERR_ACC_MOTION1,
     ERR_ACC_MOTION2,
     ERR_GYRO_MOTION1,
     ERR_GYRO_MOTION2,
 )
 
-__all__ = ["ERR_ACC_MOTION1", "ERR_ACC_MOTION2", "ERR_GYRO_MOTION1", "ERR_GYRO_MOTION2"]
+__all__ = [
+    "ERR_ACC_MOTION1",
+    "ERR_ACC_MOTION2",
+    "ERR_GYRO_MOTION1",
+    "ERR_GYRO_MOTION2",
+    "DEFAULT_P0_VALUE",
+]

--- a/src/smsfusion/constants/_constants.py
+++ b/src/smsfusion/constants/_constants.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 ERR_ACC_MOTION1 = {
     "N": 0.004,  # (m/s^2)/sqrt(Hz)
     "B": 0.0007,  # m/s^2
@@ -22,4 +24,4 @@ ERR_GYRO_MOTION2 = {
     "tau_cb": 50.0,  # s
 }
 
-DEFAULT_P0_VALUE = 1e-6
+P0 = np.eye(12) * 1e-6

--- a/src/smsfusion/constants/_constants.py
+++ b/src/smsfusion/constants/_constants.py
@@ -21,3 +21,5 @@ ERR_GYRO_MOTION2 = {
     "B": 0.00003,  # rad/s
     "tau_cb": 50.0,  # s
 }
+
+DEFAULT_P0_VALUE = 1e-6

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pytest import approx
 
 from smsfusion import constants
@@ -63,6 +64,6 @@ def test_ERR_GYRO_MOTION2():
         assert err_out[key_i] == approx(err_expect[key_i])
 
 
-def test_DEFAULT_P0_VALUE():
-    p0_expect = 1.0e-6
-    assert constants.DEFAULT_P0_VALUE == p0_expect
+def test_P0():
+    p0_expect = np.eye(12) * 1.0e-6
+    np.testing.assert_almost_equal(constants.P0, p0_expect)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -61,3 +61,8 @@ def test_ERR_GYRO_MOTION2():
 
     for key_i in err_expect:
         assert err_out[key_i] == approx(err_expect[key_i])
+
+
+def test_DEFAULT_P0_VALUE():
+    p0_expect = 1.0e-6
+    assert constants.DEFAULT_P0_VALUE == p0_expect

--- a/tests/test_ins.py
+++ b/tests/test_ins.py
@@ -39,7 +39,7 @@ from smsfusion.benchmark import (
     benchmark_full_pva_beat_202311A,
     benchmark_full_pva_chirp_202311A,
 )
-from smsfusion.constants import DEFAULT_P0_VALUE, ERR_ACC_MOTION2, ERR_GYRO_MOTION2
+from smsfusion.constants import ERR_ACC_MOTION2, ERR_GYRO_MOTION2, P0
 from smsfusion.noise import IMUNoise, white_noise
 
 
@@ -771,7 +771,7 @@ class Test_AidedINS:
         assert ains._err_acc == ERR_ACC_MOTION2
         assert ains._err_gyro == ERR_GYRO_MOTION2
 
-        np.testing.assert_allclose(ains._P_prior, np.eye(12) * DEFAULT_P0_VALUE)
+        np.testing.assert_allclose(ains._P_prior, P0)
         assert ains._P.shape == (12, 12)
         assert ains._F.shape == (12, 12)
         assert ains._G.shape == (12, 9)
@@ -784,9 +784,9 @@ class Test_AidedINS:
         x0 = np.zeros(16)
         x0[6] = 1.0
         if ignore_bias_acc:
-            P0_prior = np.eye(15) * DEFAULT_P0_VALUE
+            P0_prior = np.eye(15) * 1e-6
         else:
-            P0_prior = np.eye(12) * DEFAULT_P0_VALUE
+            P0_prior = P0
         with pytest.raises(ValueError):
             AidedINS(10.24, x0, P0_prior, ignore_bias_acc=ignore_bias_acc)
 
@@ -1819,7 +1819,7 @@ class Test_VRU:
 
         assert ains._err_acc == ERR_ACC_MOTION2
         assert ains._err_gyro == ERR_GYRO_MOTION2
-        np.testing.assert_allclose(ains._P_prior, np.eye(12) * DEFAULT_P0_VALUE)
+        np.testing.assert_allclose(ains._P_prior, P0)
 
     def test_update_compare_to_ains(self):
         """Update using aiding variances in update method."""
@@ -1963,7 +1963,7 @@ class Test_AHRS:
 
         assert ains._err_acc == ERR_ACC_MOTION2
         assert ains._err_gyro == ERR_GYRO_MOTION2
-        np.testing.assert_allclose(ains._P_prior, np.eye(12) * DEFAULT_P0_VALUE)
+        np.testing.assert_allclose(ains._P_prior, P0)
 
     def test_update_compare_to_ains(self):
         """Update using aiding variances in update method."""


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
Introduces a default error covariance matrix for the different INS classes along with making the SMS Motion 2 noise parameters default.

Removed some text from the `P0_prior` description in `VRU` and `AHRS` docstrings as the matrix size will be 12x12 as they both call `super().__init__()` with `ignore_bias_acc=True`.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
