### PR TITLE
Use `typing.Self` to annotate methods returning `self`.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-### This PR is related to user story DLAB-
-
 ## Description
 Provide a short description about the work that has been done.
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"] 
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,4 +36,4 @@ jobs:
 
       - name: Build documentation
         run: hatch run docs:build
-        if: ${{ (matrix.python-version == '3.10') && (matrix.os == 'ubuntu-latest')}}
+        if: ${{ (matrix.python-version == '3.12') && (matrix.os == 'ubuntu-latest')}}

--- a/.github/workflows/deploy_public.yaml
+++ b/.github/workflows/deploy_public.yaml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ authors = [
 ]
 description = "Sensor fusion algorithms and utilities for SMS Motion"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 from numba import njit
@@ -451,7 +451,7 @@ class StrapdownINS(INSMixin):
         f_imu: ArrayLike,
         w_imu: ArrayLike,
         degrees: bool = False,
-    ) -> "StrapdownINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11:
+    ) -> Self:
         """
         Update the INS states by integrating the *strapdown navigation equations*.
 
@@ -950,7 +950,7 @@ class AidedINS(INSMixin):
         head_degrees: bool = True,
         g_ref: bool = False,
         g_var: ArrayLike | None = None,
-    ) -> "AidedINS":  # TODO: Replace with ``typing.Self`` when Python > 3.11
+    ) -> Self:
         """
         Update/correct the AINS' state estimate with aiding measurements, and project
         ahead using IMU measurements.
@@ -1190,7 +1190,7 @@ class VRU(AidedINS):
         degrees: bool = False,
         pos_var: ArrayLike = np.array([1e6, 1e6, 1e6]),
         vel_var: ArrayLike = np.array([1e2, 1e2, 1e2]),
-    ) -> "VRU":  # TODO: Replace with ``typing.Self`` when Python > 3.11
+    ) -> Self
         """
         Update/correct the VRU's state estimate with pseudo aiding measurements
         (i.e., zero velocity and zero position with corresponding variances), and
@@ -1325,7 +1325,7 @@ class AHRS(AidedINS):
         head_degrees: bool = True,
         pos_var: ArrayLike = np.array([1e6, 1e6, 1e6]),
         vel_var: ArrayLike = np.array([1e2, 1e2, 1e2]),
-    ) -> "AHRS":  # TODO: Replace with ``typing.Self`` when Python > 3.11
+    ) -> Self
         """
         Update/correct the AHRS' state estimate with pseudo aiding measurements
         (i.e., zero velocity and zero position with corresponding variances), and

--- a/src/smsfusion/_ins.py
+++ b/src/smsfusion/_ins.py
@@ -1190,7 +1190,7 @@ class VRU(AidedINS):
         degrees: bool = False,
         pos_var: ArrayLike = np.array([1e6, 1e6, 1e6]),
         vel_var: ArrayLike = np.array([1e2, 1e2, 1e2]),
-    ) -> Self
+    ) -> Self:
         """
         Update/correct the VRU's state estimate with pseudo aiding measurements
         (i.e., zero velocity and zero position with corresponding variances), and
@@ -1325,7 +1325,7 @@ class AHRS(AidedINS):
         head_degrees: bool = True,
         pos_var: ArrayLike = np.array([1e6, 1e6, 1e6]),
         vel_var: ArrayLike = np.array([1e2, 1e2, 1e2]),
-    ) -> Self
+    ) -> Self:
         """
         Update/correct the AHRS' state estimate with pseudo aiding measurements
         (i.e., zero velocity and zero position with corresponding variances), and


### PR DESCRIPTION
### This PR is related to user story DLAB-

## Description
Use `typing.Self` to annotate methods returning `self`.
Also, upgrade minimum requirement to Python 3.11 (to allow typing.Self support)

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below).
- [x] Correct label(s) are used.


PR title tips:
* Use imperative mood.
* Describe the motivation for change, issue that has been solved or what has been improved - not how.
* Examples:
  * Add functionality for Allan variance to smsfusion.simulate
  * Upgrade to support Python 3.10
  * Remove MacOS from CI
